### PR TITLE
feat: add brainstorming, prd, writing-plans, executing-plans skills

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: brainstorming
+description: "Standalone exploration tool for turning ideas into designs — usable at any point in the dev cycle (PRD writing, plan writing, debugging, or standalone exploration). Explores user intent, requirements and design before implementation."
+---
+
+# Brainstorming Ideas Into Designs
+
+## Overview
+
+Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
+
+Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## Checklist
+
+You MUST create a task for each of these items and complete them in order:
+
+1. **Explore project context** — check files, docs, recent commits
+2. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+3. **Propose 2-3 approaches** — with trade-offs and your recommendation
+4. **Present design** — in sections scaled to their complexity, get user approval after each section
+5. **Invoke grill-me** — use the `grill-me` skill (`Skill` tool, `skill: "grill-me"`) to stress-test the approved design. `grill-me` will NOT re-invoke brainstorming — it produces a Resolved/Unresolved/Risk summary only. Continue only after that summary is generated.
+6. **Resolved / Unresolved / Deferred summary** — output a short bullet list per category:
+   - **Resolved:** decisions that are settled
+   - **Unresolved:** open questions that must be answered before implementation begins
+   - **Deferred:** items deliberately set aside (not blocking now)
+   If Unresolved is non-empty, stop and resolve those questions before continuing.
+
+**Brainstorming ends here.** After the resolved/unresolved/deferred summary is presented, the session is complete. The user will invoke `/prd` and `writing-plans` when they are ready — do not auto-invoke them.
+
+## Godot Constraint Checklist
+
+When designing any Godot feature, explicitly address these in your design:
+
+| Constraint | Question to answer |
+|------------|-------------------|
+| **Autoloads** | Does this touch a singleton (GameState, CraftingSystem, DayManager, DialogueManager)? Which signals are emitted/connected? |
+| **Scene tree** | Which scene owns this node? Is it instanced or a child? Does it need `@onready`? |
+| **Signals** | Does UI poll state or connect to signals? (Must connect — never poll.) |
+| **GDScript** | Any typed arrays, custom resources, or `@export` vars needed? |
+| **Testability** | Which logic can be GUT-tested headlessly (`godot --headless -s addons/gut/gut_cmdln.gd`)? |
+| **Mobile renderer** | Any shaders, post-processing, or features incompatible with the Mobile renderer? |
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Explore project context" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design sections" [shape=box];
+    "User approves design?" [shape=diamond];
+    "Invoke grill-me skill" [shape=box];
+    "Resolved/Unresolved/Deferred summary" [shape=box];
+    "Unresolved items?" [shape=diamond];
+    "Done (user invokes /prd or writing-plans when ready)" [shape=doublecircle];
+
+    "Explore project context" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design sections";
+    "Present design sections" -> "User approves design?";
+    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Invoke grill-me skill" [label="yes"];
+    "Invoke grill-me skill" -> "Resolved/Unresolved/Deferred summary";
+    "Resolved/Unresolved/Deferred summary" -> "Unresolved items?";
+    "Unresolved items?" -> "Ask clarifying questions" [label="yes, resolve first"];
+    "Unresolved items?" -> "Done (user invokes /prd or writing-plans when ready)" [label="no"];
+}
+```
+
+## The Process
+
+**Understanding the idea:**
+- Check out the current project state first (files, docs, recent commits)
+- Ask questions one at a time to refine the idea
+- Prefer multiple choice questions when possible, but open-ended is fine too
+- Only one question per message — if a topic needs more exploration, break it into multiple questions
+- Focus on understanding: purpose, constraints, success criteria
+
+**Exploring approaches:**
+- Propose 2-3 different approaches with trade-offs
+- Present options conversationally with your recommendation and reasoning
+- Lead with your recommended option and explain why
+
+**Presenting the design:**
+- Once you believe you understand what you're building, present the design
+- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
+- Ask after each section whether it looks right so far
+- Cover: architecture, components, data flow, error handling, testing
+- Work through the Godot Constraint Checklist explicitly for any Godot feature
+- Be ready to go back and clarify if something doesn't make sense
+
+## Key Principles
+
+- **One question at a time** — don't overwhelm with multiple questions
+- **Multiple choice preferred** — easier to answer than open-ended when possible
+- **YAGNI ruthlessly** — remove unnecessary features from all designs
+- **Explore alternatives** — always propose 2-3 approaches before settling
+- **Incremental validation** — present design, get approval before moving on
+- **Be flexible** — go back and clarify when something doesn't make sense
+- **Godot constraints first** — work through the constraint checklist before finalizing any Godot design

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: executing-plans
+description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+---
+
+# Executing Plans
+
+## Overview
+
+Load plan, review critically, execute tasks in batches, report for review between batches.
+
+**Core principle:** Batch execution with checkpoints for architect review.
+
+**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+
+## The Process
+
+### Step 1: Confirm Branch
+
+Before reading the plan or touching any file, confirm you are on the correct feature branch (not `master`):
+
+```bash
+git branch --show-current
+pwd
+```
+
+Expected: current branch is a feature branch (not `master`). If on master, create or switch to a feature branch before proceeding.
+
+### Step 2: Sync with master
+
+Pull and merge latest master:
+```bash
+git fetch origin && git merge origin/master
+```
+NEVER use `git merge master` alone — the local master ref may be stale. Resolve any conflicts before proceeding.
+
+### Step 3: Load and Review Plan
+
+1. Read plan file
+2. Review critically — identify any questions or concerns about the plan
+3. If concerns: raise them with your human partner before starting
+4. If no concerns: create TodoWrite tasks and proceed
+
+### Step 4: Execute Batch
+
+**Before dispatching any task, read the parallel dispatch source of truth (priority order):**
+
+1. **Primary:** Find the `#### Parallel Execution Groups` table for the current batch in the plan. Dispatch all tasks in a `(parallel)` group as concurrent implementer Agent calls in a **single message** (max 3).
+2. **Fallback:** If no group table exists, scan each task's `**Parallelizable with:**` annotation. Batch tasks that name each other into a single message.
+3. **Last resort:** If neither exists, run tasks sequentially.
+
+**Batch atomicity rule (HARD):** If ANY implementer in a parallel group fails, halt the entire batch immediately. Passing implementers MUST discard their in-progress work — do NOT stage or commit partial results. Fix the failure, then re-dispatch the entire group from scratch.
+
+For each task (whether parallel or sequential):
+1. Mark as in_progress
+2. Determine task type:
+   - **GDScript task** (creates or modifies `.gd` files with logic): follow the TDD cycle — write failing GUT test, write implementation, run tests to pass, refactor checkpoint, commit.
+   - **Non-logic task** (scenes, docs, assets): follow each step exactly as written in the plan.
+3. After completing any GDScript task: run the full test suite to confirm no regressions:
+   ```bash
+   godot --headless -s addons/gut/gut_cmdln.gd
+   ```
+   If any test fails, stop and fix before continuing.
+4. Run verifications as specified in the plan
+5. Mark as completed
+
+**Parallel reviewer rule (within each batch):**
+After each task's work is committed, dispatch spec and quality reviewers as two concurrent Agent calls in a single message. Both must pass before marking the task complete.
+
+### Step 5: Report
+
+When batch complete:
+- Show what was implemented
+- Show verification output
+- Say: "Ready for feedback."
+
+### Step 6: Continue
+
+Based on feedback:
+- Apply changes if needed
+- Execute next batch
+- Repeat until complete
+
+### Step 7: Complete Development
+
+After all tasks complete and verified, run the smoketest sequence:
+
+**Step 1: Fetch and merge latest master**
+```bash
+git fetch origin && git merge origin/master
+```
+
+**Step 2: Run all GUT tests**
+```bash
+godot --headless -s addons/gut/gut_cmdln.gd
+```
+Expected: All tests pass, zero failures.
+
+**Step 3: Launch game and verify visually**
+```bash
+godot
+```
+Tell the user what to verify. Wait for confirmation before continuing.
+
+Only after the user confirms the game looks correct:
+- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
+- Follow that skill to verify tests, present options, execute choice.
+
+### Step 8: Lessons Learned — HARD GATE (do not skip)
+
+After the smoketest passes, **before pushing or creating the PR**, explicitly ask:
+
+> "Any important lessons learned from this implementation? (e.g. surprises, sharp edges, things that should update CLAUDE.md / skills / agents / memory)"
+
+**This step is mandatory — do not skip it, even if the implementation felt smooth.**
+
+- If **yes** or the user provides lessons: invoke the `/prd` skill to create a GitHub issue capturing the needed documentation updates. Save anything session-relevant to memory as well.
+- If the user explicitly says **no lessons**: note that in your response and proceed to push/PR.
+
+Do not push or open the PR until you have received an explicit answer to this question.
+
+## When to Stop and Ask for Help
+
+**STOP executing immediately when:**
+- Hit a blocker mid-batch (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- You don't understand an instruction
+- Verification fails repeatedly
+
+**Ask for clarification rather than guessing.**
+
+## When to Revisit Earlier Steps
+
+**Return to Review (Step 3) when:**
+- Partner updates the plan based on your feedback
+- Fundamental approach needs rethinking
+
+**Don't force through blockers** — stop and ask.
+
+## Remember
+- Confirm feature branch FIRST before any other action
+- Review plan critically before starting
+- Follow plan steps exactly
+- Don't skip verifications
+- Between batches: just report and wait
+- Stop when blocked, don't guess
+- Never start implementation on master branch
+- GDScript tasks: TDD cycle — failing test → implementation → passing test → refactor → commit
+- Run full test suite after every GDScript task to catch regressions
+- Merge command is `git fetch origin && git merge origin/master`
+- Parallel implementers: read `#### Parallel Execution Groups` table first; dispatch parallel groups as concurrent Agent calls (max 3); batch atomicity — if any fails, ALL discard and retry from scratch
+- Parallel reviewers: fire spec + quality in one message after each implementer commit
+
+## Integration
+
+**Required workflow skills:**
+- **superpowers:writing-plans** — creates the plan this skill executes
+- **superpowers:finishing-a-development-branch** — complete development after all tasks
+- **dispatching-parallel-agents** — consult before any agent dispatch decision

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: prd
+description: Use when creating a new PRD for a feature — creates a GitHub issue with the PRD content. No local file is created. Can be used with or without a prior brainstorming session.
+---
+
+## Before You Begin
+
+Always invoke the `grill-me` skill — it will surface requirements, acceptance criteria, scope, and Godot constraints. Once grill-me is satisfied, proceed to drafting.
+
+---
+
+Create a new PRD as a GitHub issue.
+
+## Steps
+
+1. **Draft the PRD content** from the brainstorming session or the user's description. Use this structure:
+
+```
+## Goal
+One sentence: what this feature does and why it matters for the game.
+
+## Requirements
+- R1: ...
+
+## Acceptance Criteria
+- [ ] AC1: ...
+
+## Out of Scope
+- ...
+
+## Files Impacted
+- `scenes/foo.tscn` — ...
+- `scripts/foo.gd` — ...
+
+## Notes
+<!-- Technical context: scenes impacted, autoload signals added/changed,
+     GUT test coverage plan, Mobile renderer concerns, open questions -->
+```
+
+   **Required in Notes:** include any relevant technical context gathered during design — which autoload signals are added or changed, what GUT tests cover the logic, any Mobile renderer concerns, and specific files impacted when known. This ensures subsequent sessions start informed.
+
+2. **Create a GitHub issue** with the full PRD content as the body:
+   ```sh
+   gh issue create --repo MatthieuGagne/outpost-nova --title "feat: <feature name>" --body "<PRD content>"
+   ```
+   Capture the issue number from the URL in the output.
+
+3. Report the issue URL to the user.
+
+## Updating an Existing PRD
+
+When updating a PRD (e.g., after a new brainstorming session or scope change):
+
+- **Always use `gh issue edit`** to rewrite the issue body directly — never add a comment:
+  ```sh
+  gh issue edit <N> --repo MatthieuGagne/outpost-nova --body "<full updated PRD content>"
+  ```
+- The issue body is the single source of truth — it must always reflect the current design.
+
+## Important
+
+- **No local file is created.** The GitHub issue is the single source of truth for the PRD.
+- Do NOT invoke `writing-plans` after this. The implementation plan is written in a separate session when the user is ready to build.

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code. Can be used with or without a prior brainstorming session.
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+## Before You Begin
+
+**First action before anything else:** Pull and merge latest master into the current branch:
+```bash
+git fetch origin && git merge origin/master
+```
+Resolve any conflicts before proceeding.
+
+**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
+
+**Last step before writing:** Always invoke the `grill-me` skill — it will surface requirements, acceptance criteria, scope, and Godot constraints. Once grill-me is satisfied, proceed to writing the plan.
+
+## Hard Gate Sequence
+
+Every task that touches GDScript logic MUST follow this exact sequence — no exceptions:
+
+| Step | Action |
+|------|--------|
+| 1 | Write failing GUT test (`godot --headless -s addons/gut/gut_cmdln.gd` → FAIL) |
+| 2 | Write minimal GDScript implementation |
+| 3 | Run tests (`godot --headless -s addons/gut/gut_cmdln.gd` → PASS) |
+| 4 | Refactor checkpoint ("breaks when N > 1?") |
+| 5 | Commit |
+
+Non-logic tasks (scenes, UI, docs, assets): write → verify visually in editor → commit. No test gate.
+
+**Scene/UI gate:** If the plan touches any game state (add/remove autoload state, change signal definitions, change story beat triggers), add a task to verify all existing GUT tests still pass. Always ask the user before modifying existing tests — do not auto-update them.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Smoketestable Batches
+
+**Tasks MUST be grouped into batches of 2-4.** Each batch ends with a **Smoketest Checkpoint** — a point where the game runs and the user confirms it looks correct.
+
+A good batch boundary = any point where the game should visually work end-to-end (even partially). If a batch cannot be independently smoke-tested, the plan must explain why.
+
+### Dependency Analysis (required before writing each smoketest checkpoint block)
+
+After drafting all tasks in a batch, before inserting the Smoketest Checkpoint block:
+
+1. List all output files for each task in the batch
+2. Mark as **sequential** any two tasks that write the same file, or where Task B depends on a symbol Task A defines
+3. Group remaining tasks into independent layers — tasks with the same `Depends on` set are parallelizable with each other
+4. Go back and fill in `**Depends on:**` and `**Parallelizable with:**` on each task
+5. Insert a `#### Parallel Execution Groups` table immediately before the Smoketest Checkpoint block (use the template below)
+
+Use this template for the parallel group table that precedes every checkpoint:
+
+```markdown
+#### Parallel Execution Groups — Smoketest Checkpoint N
+
+| Group | Tasks | Notes |
+|-------|-------|-------|
+| A (parallel) | Task 1, Task 2 | Different output files, no shared state |
+| B (sequential) | Task 3 | Depends on Group A — must run after both complete |
+```
+
+````markdown
+### Smoketest Checkpoint N — [what to verify]
+
+**Step 1: Fetch and merge latest master**
+```bash
+git fetch origin && git merge origin/master
+```
+
+**Step 2: Run all GUT tests**
+```bash
+godot --headless -s addons/gut/gut_cmdln.gd
+```
+Expected: All tests pass, zero failures.
+
+**Step 3: Launch game and verify visually**
+```bash
+godot
+```
+
+**Step 4: Confirm with user**
+Tell the user what to verify in the running game. Wait for confirmation before proceeding to the next batch.
+````
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+## Open questions (must resolve before starting)
+
+- [Question 1 — or delete this line if none]
+
+---
+```
+
+## GDScript Task Template
+
+Use this template for any task that creates or modifies GDScript logic:
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create/Modify: `scripts/foo.gd`
+- Test: `tests/test_foo.gd`
+
+**Depends on:** none   ← or "Task N, Task M"
+**Parallelizable with:** none   ← or "Task N, Task M"
+
+**Step 1: Write the failing GUT test**
+
+```gdscript
+extends GutTest
+
+func before_each():
+    GameState.reset()
+
+func test_foo_initial_state():
+    assert_eq(GameState.get_resource("rations"), 0)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
+Expected: FAIL (undefined method or assertion error)
+
+**Step 3: Write minimal implementation**
+
+```gdscript
+# scripts/foo.gd
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
+Expected: PASS
+
+**Step 5: Refactor checkpoint**
+
+Ask: "Does this implementation generalize, or did I hard-code something that breaks when N > 1?"
+- If generalized: proceed.
+- If hard-coded and not fixing now: open a follow-up GitHub issue immediately before closing this task.
+
+**Step 6: Commit**
+
+```bash
+git add scripts/foo.gd tests/test_foo.gd
+git commit -m "feat: add foo"
+```
+````
+
+## Non-Logic Task Template
+
+Use this template for tasks that do NOT involve GDScript logic (scenes, docs, assets):
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create/Modify: `scenes/foo.tscn`
+
+**Depends on:** none   ← or "Task N, Task M"
+**Parallelizable with:** none   ← or "Task N, Task M"
+
+**Step 1: Write the content**
+
+[exact content or description of changes]
+
+**Step 2: Verify**
+
+[manual check or command, e.g. "open in Godot editor and confirm X is visible"]
+
+**Step 3: Commit**
+
+```bash
+git add scenes/foo.tscn
+git commit -m "feat: add foo scene"
+```
+````
+
+## Remember
+- Exact file paths always
+- Complete code in plan (not "add validation")
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- GDScript logic tasks ALWAYS get the 6-step template
+- Group tasks into batches of 2-4; each batch MUST end with a Smoketest Checkpoint
+- Annotate every task with `**Depends on:**` and `**Parallelizable with:**` — executor reads these; vague hints are not enough
+- Insert a `#### Parallel Execution Groups` table before every Smoketest Checkpoint block — this is the executor's source of truth for parallel dispatch
+
+## Lessons Learned Gate
+
+**Note for plan authors:** The `executing-plans` skill includes a final "Lessons Learned" step that runs after the smoketest passes. The implementer will ask the user whether any lessons should be captured as documentation updates (CLAUDE.md, memory, skills, or agents). No action is needed in the plan itself — this gate runs automatically at execution time.
+
+## Plan Self-Review Checklist (HARD STOP before presenting to user)
+
+Before offering the execution handoff, run this checklist. Fix any failures before proceeding.
+
+| # | Check | Pass criteria |
+|---|-------|---------------|
+| 1 | **No hardcoded values** | Every numeric constant, node path, or resource ID is sourced from a named constant or explicit reference — never a magic value |
+| 2 | **All tasks have explicit test criteria** | Every task states exactly how to verify it passes (command + expected output, or visual check description) |
+| 3 | **Parallel annotations justified** | Every task has `**Depends on:**` and `**Parallelizable with:**` filled in. Any `**Parallelizable with:** none` MUST be followed by a one-sentence justification. An unjustified `none` is a plan defect. |
+| 4 | **Parallel Execution Groups tables present** | Every batch that precedes a Smoketest Checkpoint has a `#### Parallel Execution Groups` table |
+| 5 | **No implementation details leaked from brainstorming** | Plan contains file paths and task steps, not design narrative or requirement rationale (those belong in the GitHub issue) |
+
+**Failure handling:**
+- Checks #1, #2, #4, #5 fail → fix the plan now and re-run the checklist from the top.
+- Check #3 fails (unjustified `none`) → do NOT silently fix. Present the plan WITH the Incomplete Warning block below, immediately after the plan header. The user decides whether to proceed or fix first.
+
+### Incomplete Warning Block (use when check #3 fails)
+
+```markdown
+> ⚠️ **Plan incomplete — unjustified parallelism annotations**
+>
+> The following tasks have `**Parallelizable with:** none` with no justification sentence:
+> - Task N: [task name]
+>
+> For each: either (a) identify tasks it can parallelize with and update the annotation,
+> or (b) add a one-sentence justification explaining why it cannot parallelize
+> (e.g., "writes same file as Task M", "requires Task M's output").
+>
+> Proceed with the plan as-is, or fix these annotations first?
+```
+
+## Execution Handoff
+
+After saving the plan, **present the full plan to the user**.
+
+<HARD-GATE>
+Do NOT offer execution options until the user gives an explicit affirmative approval (e.g., "yes", "looks good", "let's go", "proceed", or equivalent). Do not interpret silence or continued conversation as approval.
+</HARD-GATE>
+
+Only after explicit affirmative, offer execution choice:
+
+**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Stay in this session
+- Fresh subagent per task + code review
+
+**If Parallel Session chosen:**
+- Guide them to open new session
+- **REQUIRED SUB-SKILL:** New session uses superpowers:executing-plans


### PR DESCRIPTION
Closes #9

## Summary
- Ports and adapts the four design-before-implementation skills from nuke-raider to outpost-nova
- No GB-specific content (no GBDK, bank gates, Emulicious, memory checks)
- PRD skill targets `MatthieuGagne/outpost-nova` for `gh issue` commands
- Writing-plans skill uses GDScript task template with GUT test gates
- Executing-plans skill uses `godot --headless` GUT smoketest as its verification step

## Test plan
- [ ] Invoke `/brainstorm` in an outpost-nova session — Godot constraint checklist appears, no GB checklist
- [ ] Invoke `/prd` — creates a GitHub issue on `MatthieuGagne/outpost-nova`
- [ ] Invoke `/writing-plans` — generated plan includes GUT test steps, not `make test`/bank gates
- [ ] Invoke `/executing-plans` — headless GUT test is the verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)