### PR TITLE
feat: character creation layout fix and keyboard navigation

### DIFF
--- a/data/themes/character_creation_theme.tres
+++ b/data/themes/character_creation_theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=3 format=3]
+[gd_resource type="Theme" load_steps=4 format=3]
 
 [ext_resource type="FontFile" path="res://data/fonts/m5x7.tres" id="1"]
 
@@ -11,7 +11,11 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(1, 1, 1, 1)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2"]
+bg_color = Color(1, 1, 1, 0.3)
+
 [resource]
 Button/fonts/font = ExtResource("1")
 Label/fonts/font = ExtResource("1")
 Button/styles/focus = SubResource("StyleBoxFlat_1")
+Button/styles/pressed = SubResource("StyleBoxFlat_2")

--- a/scenes/character_creation.tscn
+++ b/scenes/character_creation.tscn
@@ -3,6 +3,10 @@
 [ext_resource type="Script" uid="uid://cnm3hfp72i82p" path="res://scripts/ui/character_creation.gd" id="1"]
 [ext_resource type="Theme" path="res://data/themes/character_creation_theme.tres" id="2"]
 
+[sub_resource type="ButtonGroup" id="ButtonGroup_1"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_2"]
+
 [node name="CharacterCreation" type="Control" unique_id=1216842655]
 layout_mode = 3
 anchors_preset = 15
@@ -48,17 +52,23 @@ layout_mode = 2
 
 [node name="Appearance0" type="Button" parent="VBoxContainer/AppearancePicker" unique_id=600960377]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_1")
 text = "A"
 focus_neighbor_right = NodePath("../Appearance1")
 
 [node name="Appearance1" type="Button" parent="VBoxContainer/AppearancePicker" unique_id=98444489]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_1")
 text = "B"
 focus_neighbor_left = NodePath("../Appearance0")
 focus_neighbor_right = NodePath("../Appearance2")
 
 [node name="Appearance2" type="Button" parent="VBoxContainer/AppearancePicker" unique_id=1684006321]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_1")
 text = "C"
 focus_neighbor_left = NodePath("../Appearance1")
 
@@ -72,20 +82,27 @@ theme_override_constants/separation = 4
 
 [node name="Engineer" type="Button" parent="VBoxContainer/BackgroundPicker" unique_id=574058161]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_2")
 text = "Engineer (starts with Parts)"
 focus_neighbor_bottom = NodePath("../Medic")
 
 [node name="Medic" type="Button" parent="VBoxContainer/BackgroundPicker" unique_id=395805715]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_2")
 text = "Medic (starts with Rations)"
 focus_neighbor_top = NodePath("../Engineer")
 focus_neighbor_bottom = NodePath("../Drifter")
 
 [node name="Drifter" type="Button" parent="VBoxContainer/BackgroundPicker" unique_id=684165331]
 layout_mode = 2
+toggle_mode = true
+button_group = SubResource("ButtonGroup_2")
 text = "Drifter (starts with Energy Cells)"
 focus_neighbor_top = NodePath("../Medic")
 
 [node name="StartBtn" type="Button" parent="VBoxContainer" unique_id=67328775]
 layout_mode = 2
+disabled = true
 text = "Begin"

--- a/scripts/ui/character_creation.gd
+++ b/scripts/ui/character_creation.gd
@@ -8,27 +8,38 @@ extends Control
 
 const BACKGROUNDS = ["engineer", "medic", "drifter"]
 
-var _selected_appearance: int = 0
-var _selected_background: String = "drifter"
+var _selected_appearance: int = -1
+var _selected_background: String = ""
 
 func _ready() -> void:
 	start_btn.pressed.connect(_on_start)
 	name_input.text_submitted.connect(_on_start.unbind(1))
+	name_input.text_changed.connect(_update_start_btn)
 	for i in appearance_picker.get_child_count():
 		appearance_picker.get_child(i).pressed.connect(_set_appearance.bind(i))
 	for i in background_picker.get_child_count():
 		background_picker.get_child(i).pressed.connect(_set_background.bind(i))
+	name_input.grab_focus()
+	_update_start_btn()
 
 func _set_appearance(idx: int) -> void:
 	_selected_appearance = idx
+	_update_start_btn()
 
 func _set_background(idx: int) -> void:
 	_selected_background = BACKGROUNDS[idx]
+	_update_start_btn()
+
+func _update_start_btn(_ignored: String = "") -> void:
+	start_btn.disabled = (
+		name_input.text.strip_edges() == "" or
+		_selected_appearance == -1 or
+		_selected_background == ""
+	)
 
 func _on_start() -> void:
-	var name_val = name_input.text.strip_edges()
-	if name_val == "":
-		name_val = "Crew"
-	GameState.set_player_identity(name_val, _selected_background, _selected_appearance)
+	if start_btn.disabled:
+		return
+	GameState.set_player_identity(name_input.text.strip_edges(), _selected_background, _selected_appearance)
 	GameState.apply_background_bonus(_selected_background)
 	get_tree().change_scene_to_file("res://scenes/main.tscn")


### PR DESCRIPTION
## Summary
- Fix character creation screen layout to fit the 480×270 viewport
- Add full keyboard navigation (Tab/Arrow/Enter) with focus ring styling via Theme
- Auto-focus name input on load, highlight selected options, and block Begin until name + appearance + background are all chosen

## Test Plan
- [ ] GUT tests pass headlessly (33/33)
- [ ] Visual smoketest confirmed