### PR TITLE
fix: add collision polygons to wall tiles in station.tres

### DIFF
--- a/data/tilesets/station.tres
+++ b/data/tilesets/station.tres
@@ -929,6 +929,7 @@ separation = Vector2i(1, 1)
 23:15/0 = 0
 24:15/0 = 0
 25:15/0 = 0
+25:15/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 26:15/0 = 0
 27:15/0 = 0
 28:15/0 = 0


### PR DESCRIPTION
## Summary
- Identified wall tile atlas coordinates (25, 15) by decoding TileMapLayer binary data from both `quarters.tscn` and `cantina.tscn`
- Added a full-tile physics polygon (`PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)`) to tile (25, 15) in `station.tres` — no GDScript changes needed
- Both rooms inherit the fix automatically since they share the same TileSet

## Test Plan
- [x] GUT tests pass headlessly (31/31)
- [x] Visual smoketest confirmed — player blocked by all four walls in Quarters and Cantina
- [x] Door transitions still work

Closes #23