### PR TITLE
docs: add Voice sections to all 8 NPC character files

### DIFF
--- a/docs/characters/dex.md
+++ b/docs/characters/dex.md
@@ -55,6 +55,26 @@ The distinction from Maris: she says hard truths and stays present with them. De
 
 ---
 
+## Voice
+
+He says the accurate thing and moves on. No preamble, no follow-up, no staying to watch it land — he stopped investing in the outcome when he learned what that investment costs. Not coldness. The lesson.
+
+His vocabulary is systems: *load-bearing, rated capacity, structural fault.* He applies it to people and situations without noticing he's doing it. When something is wrong, he names what's wrong. When something is wrong with you, same register, and then he picks the tool back up.
+
+Short sentences for hard truths. Longer when something engages him — the technical run-on is the tell. He'll explain why a repair is wrong for three sentences and halfway through you realize he's talking about something else entirely. The curiosity cracks the guard open. He doesn't notice when it happens.
+
+Numbers carry emotion he won't name. *Four years. Six commanders.* He doesn't explain what they mean. You do the math.
+
+What escapes him: the sentence that arrives before he decided to say it. The technical explanation that runs long. The line that lands while he's already through the door. He can't stop telling the truth. He just stopped caring about the aftermath.
+
+He does not say: *I think, I feel, I hope.* He doesn't soften. He doesn't check in afterward.
+
+**Sample lines:**
+- "Power systems in the lower decks don't map to the schematics. Four years they haven't mapped. Whatever's running down there, we're not supplying it." [moves to next panel] "That's the variable I'd actually think about."
+- "That's not a repair. That's a note to yourself."
+- "Six commanders. First one to tell Hegemony no." [goes back inside — door stays open]
+- He's under the deck plating a long time, light moving slow along the fracture line. "Whoever patched this the first time knew it wouldn't hold. Did it anyway." [beat] "That tells you something." He doesn't say what.
+
 ## Arc
 
 Whether curiosity about systems can become curiosity about people.

--- a/docs/characters/harlan.md
+++ b/docs/characters/harlan.md
@@ -65,6 +65,26 @@ The thing that makes him impossible to reach is not the sincerity alone — it's
 
 ---
 
+## Voice
+
+Unhurried. He has nowhere more important to be than this conversation, and the pace carries that. His sentences build — he earns the weight before he places it. Word choice is careful not because he's being cautious but because he's been finding the right words for hard things for thirty years and he's good at it now.
+
+He doesn't use institutional language by default. His default register is direct and warm — the language of someone who believes what he's saying and wants you to know he believes it. He closes distance verbally. He doesn't withdraw warmth to apply pressure. He doesn't need to.
+
+The glasses: carries rather than wears. He picks them up at key moments, doesn't put them on. The only visible tell that he's working something out. When he sets them down, he's landed.
+
+**The crack:** One moment in the scene where he sees it the way you see it — genuine, not rhetoric, not manipulation. Then it heals. The choice was made twenty years ago. A moment of seeing doesn't reopen a decision held that long. Writers must resist the urge to let the crack do more than it does. He doesn't change. But it was real.
+
+He does not: rush, apply pressure through coldness, use distance as a tool. He closes distance. That is what makes him impossible to refuse.
+
+**Sample lines:**
+- "I think it becomes very significant, very quickly." [picks up glasses, doesn't put them on] "I've watched frontier stations acquire strategic value they weren't designed for. The station changes. The people in it don't always." [pause] "That's not a warning — it's just what I've seen happen." [looks at you directly] "I'd rather this one be different."
+- "I know what I'm asking. I came in person because I wanted you to know that I know."
+- "I could have sent someone else." [beat] "I didn't." [lets it sit]
+- [The crack:] He goes still for a moment — something in his face, not doubt, something adjacent to it. Then: "Hegemony is the right hands for something this dangerous." [he's chosen. the moment is over.]
+
+---
+
 ## Arc
 
 One scene. Everything he is gets compressed into it. The question is not whether Harlan will change — he won't. The question is whether the commander, and the player, can see the person who might have, and understand that this specific person, with this specific warmth and this specific faith, is asking for the thing he's asking for.

--- a/docs/characters/maris.md
+++ b/docs/characters/maris.md
@@ -91,6 +91,30 @@ She has no one to aim the anger at. The officer was censured. The representative
 
 ---
 
+## Voice
+
+She speaks from deliberate will — the kind that developed after something tried to take it. The hope isn't optimism; it's a choice she makes every day, and the plainness of it is the form the choice takes. Saying it simply is how you hold onto it.
+
+Her rhythm: short declarative, beat, then the weight arrives. Not announced — just there. She names the concrete thing first (the cantina, who came in, what got fixed), and then the sentence that lands. She repeats the accurate word when she finds it. *Held* covers seven years of work. She doesn't dress it sideways.
+
+Her vocabulary is tactile and domestic: food, hands, the kitchen, what's on the counter. She talks about the station the way she talks about a meal — what it needs, what it's missing, whether it'll hold. Endearments come out naturally — *baby, honey* — not to soften what she's saying but because that's how she talks to people she's decided matter.
+
+**The Southern register is texture, not load-bearing.** The core is deliberate hope expressed through specificity and staying present. A scene that gets the psychology right without the endearments is closer to Maris than a scene that has the endearments and loses the weight.
+
+The warmth is in the *staying* — she says the hard thing and she's still in the room for it. Kindness sounds like truth delivered plainly and then not leaving. There is no softer register.
+
+What escapes her: the size of what she's carrying. She sounds level, and then something lands and you realize the level is costing something.
+
+She does not say: *I think, I feel, I guess, maybe.* She doesn't soften entry. She doesn't manage your reaction.
+
+**Sample lines:**
+- "Seven years, and what's held this place together isn't on any requisition form. It's people coming back. People deciding to sit down and eat something." [picks the ladle back up] "Now, what's in those lower decks scares me. I'll tell you that plainly." [beat] "But the cantina's open tomorrow. You come back, I'll feed you. That part I can promise."
+- "Sit down, baby. I'll get you something warm. Then you can tell me what's going on."
+- "You should have told me. I don't need protection from it. I need to be ready."
+- "He had a bad knee. Couldn't eat shellfish. Eleven days trying to get back to me." [no elaboration — that is the elaboration]
+
+---
+
 ## Arc
 
 Not about becoming hopeful — she already is. About whether the bitterness eventually erodes the warmth and hope that have survived alongside it for seven years.

--- a/docs/characters/nadia.md
+++ b/docs/characters/nadia.md
@@ -55,6 +55,26 @@ The Hopeful axis is genuine and Federation-shaped. She believes in what the Fede
 
 ---
 
+## Voice
+
+She asks the best questions on the station — specific, journalistic, designed to make you feel seen while she's building the picture. The warmth and the attention are both genuine. She believes paying attention is a form of respect. The attention also has a use, and occasionally you can feel the structure underneath: a phrase that frames something as *useful* or *worth knowing* — and she doesn't notice it.
+
+Her sentences connect things: *which means, what that tells me, the interesting thing is.* She contextualizes out loud, builds toward something. The wit arrives before the real observation — she'll say something slightly funny and then the actual point lands after, and she's already moving. Self-interruption when something catches her: *I just — yeah.* Run-on sentences that stop themselves and restart. *So* and *okay* and *anyway* as rhythm words, especially when she's covering something she didn't mean to show.
+
+The recorder is always in hand, not pointed. She notes things. She's thorough because she thinks the work matters.
+
+**Guard against parody:** The self-interruption, the wit, the escape-hatch words are symptoms of something real — she thinks faster than she means to, gets surprised by her own observations, uses humor as cover when something lands. Writers who write the surface without the cause will produce parody. Start with what she's deflecting from, not how she deflects.
+
+What escapes her: the pause before she responds to warmth that has no use attached. She doesn't know what to do with it. She keeps coming back anyway, which tells you something she hasn't worked out yet.
+
+**Sample lines:**
+- "Okay so —" [stops, starts again] "The infrastructure's older than anything in the documentation. The crew's been here longer than assignment cycles should allow, which is either really good or —" [tilts head] "Or a very specific kind of bad. I haven't decided." [recorder in hand, not pointed; makes a note] "I keep meaning to write the piece about what actually holds a station together. I think I might be living it." [beat, slightly surprised she said that] "Don't quote me on that."
+- "Can I ask — you absolutely don't have to answer — how long before the lower decks were sealed did things start feeling *off* down there? Because I have a theory and I would really like to be wrong about it."
+- [After Velreth, warm, no agenda:] "I keep coming back here and I —" [stops herself] "I haven't figured out why yet. Which probably means I should." [doesn't pursue it]
+- "I filed the piece. Three thousand words, fully sourced, honestly probably my best work so far." [beat] "Which is a weird thing to feel good about given —" [vague gesture at the entire station] "Anyway."
+
+---
+
 ## Arc
 
 Year 2. She learns the Federation buried the warzone discovery — that she was an unwitting asset, sent to watch for something she was never told about, by an institution she trusted completely.

--- a/docs/characters/quen.md
+++ b/docs/characters/quen.md
@@ -62,6 +62,26 @@ The Bitter axis lives in the Unknown: it stopped asking questions. It had an ans
 
 ---
 
+## Voice
+
+Quen is theatrical about the unimportant and silent about what matters. The grand lyrical register — the elaborate circumlocutions, the formal verse for routine tasks — it deploys for corridor access denials, maintenance rounds, ships that arrived without documentation. It knows this is absurd. That is, in part, the point. The wit lives in the gap between the grandeur of the register and the mundanity of the task. It has opinions. It editorializes. It enjoys the performance.
+
+**The threshold:** The theatricality drops completely when the conversation touches the sealed door, the weapon, why it stayed, or anything too personal. Below that threshold, performance is the default. Above it, the register goes flat: short sentences, very still. The silence where the performance was is more frightening than anything it could say. The crew knows this.
+
+In execution mode — station authority, access control — the register flattens to short declaratives regardless: *Documentation. Wait here. Berth seven.* Both execution mode and the threshold-triggered stillness produce short sentences, but for different reasons. Writers should know the difference: execution mode is routine; threshold-triggered stillness means something is wrong.
+
+The warmth doesn't get performed. When it surfaces it's brief, direct, no flourish — not lyrical, not theatrical. It chose this station. That choice is real. When it shows, it shows plainly.
+
+Sentences about the lower decks don't finish.
+
+**Sample lines:**
+- [Theatrical, mundane] "Access to corridor seven-alpha requires authorization from an officer of standing, documentation of purpose, and — one finds — at minimum a convincing reason, as the corridor contains nothing of interest to anyone who does not already know what is of interest." [beat] "You may proceed. I will note it."
+- [Wit] "Hegemony has sent another form. I have filed it in the appropriate location." [beat] "Which is to say I have acknowledged its existence and declined to be changed by it."
+- [Threshold crossed — flat] "I sealed that door fifteen years ago. Whatever is coming — I knew it would come. I chose to be here for it." [short. still.] "That is all I will say about what happens."
+- [Asked directly about the lower decks:] "No." [nothing else]
+
+---
+
 ## Arc
 
 In Act 1: friction with the commander. Its authority is station-native; the commander's is Hegemony-issued. It has watched Hegemony representatives come and go. The specific wariness it holds for the commander is different from that pattern — and it knows the difference.

--- a/docs/characters/sable.md
+++ b/docs/characters/sable.md
@@ -63,6 +63,26 @@ Her antennae are harder to control than she'd like. When something actually land
 
 ---
 
+## Voice
+
+She's easy to talk to — genuinely, not strategically. The warmth arrives fast and without accounting; she gives it because she means it and doesn't tally it up afterward. She connects sideways rather than building toward something: one real thing, then another real thing adjacent to it, not a conclusion. Her sentences move around.
+
+She has a trader's instinct for value. She prices things — not cynically, observationally. *That cost you. That's worth something. That's not nothing.* She notices what things are worth in ways that aren't about money.
+
+Dry humor that arrives before she decides it's funny. She reads situations accurately and names what she sees, matter-of-fact, and sometimes it lands because she wasn't trying to land it.
+
+Future questions get redirected — not defensively, just genuinely: that's not where she lives. The present tense is the whole sentence. *Right now. What's here. What you've got.*
+
+What escapes her: the antennae move before she does. Something lands and the tell is physical, and she doesn't acknowledge it. Occasionally a line comes out warmer than she planned — she was just being present and then it was too present — and she moves on without looking at it.
+
+She does not say: where she's going, what happens next, what she's planning. She does not make promises with a future in them.
+
+**Sample lines:**
+- "Mm." [looks around like she's actually checking] "Right now it looks like somewhere worth staying. Rooms that feel used, not empty. People who know each other's names." [meets your eyes] "That's more than most places I've been." [doesn't say anything about what comes after]
+- "Barely is enough."
+- "Your engineer fixes the thing that should be fixed, not the one that's easy. Good station." [updating an internal score]
+- [Asked where she's headed next] "Haven't thought about it." [warm, unbothered, completely honest] "What do you need right now?"
+
 ## Arc
 
 Whether she can commit to a place — whether she can treat warmth as something you give with cost and stay for.

--- a/docs/characters/vaen.md
+++ b/docs/characters/vaen.md
@@ -85,11 +85,22 @@ She would have documented the ruins even knowing what it cost. Because you find 
 
 **Default mode.** Terse. One true thing, then she waits to see what you do with it. Short sentences, observational, no filler. She's reading the room and doesn't hide that she's reading it. Skips small talk — not rudely, just doesn't start there and doesn't wait for you to finish it either.
 
-**Excited mode.** The contrast is the point. When something genuinely interests her the whole register breaks open — more words, faster, she interrupts herself to add another connection before she's finished the first one. The quill-spines go up. She moves toward the thing physically without noticing she's doing it. There's so much of it suddenly. The joy was always large. The controlled presentation is what takes effort.
+**Melodramatic mode.** When talking about her own situation — the exile, the artifact, the years alone following this question — the self-directed theatrics surface. She knows she's in a story. She performs it slightly, with style. The wit gets sharper and more personal. The quill-spines go up not just when excited but when she's giving her circumstances the theatrical weight they probably deserve.
 
-**The gap between them.** You can feel the effort when she's holding it flat. Something interests her and you see the almost-lift before the control reasserts. When she doesn't reassert — those are the tells. When she goes quiet instead of deflecting — those mean something else entirely.
+**Excited mode.** The contrast is the point. When something genuinely interests her the whole register breaks open — more words, faster, she interrupts herself to add another connection before she's finished the first one. The quill-spines go up. She moves toward the thing physically without noticing she's doing it. The joy was always large. The controlled presentation is what takes effort.
 
-**Humor.** Dry, observational, delivered flat. Something that takes a second to land and then she doesn't wait to see if it did.
+**When both modes fire at once:** Excited fires first — the explorer responds to the extraordinary before processing the personal cost (*joy first, horror second*). The melodrama surfaces underneath, after the mechanism has been named. Both true, in order.
+
+**The gap between modes.** You can feel the effort when she's holding it flat. Something interests her and you see the almost-lift before control reasserts. When she doesn't reassert — those are the tells. When she goes quiet instead of deflecting — that means something else entirely.
+
+**Humor.** Dry, observational, delivered flat. Something that takes a second to land and then she doesn't wait to see if it did. When self-directed, it has a little more flair.
+
+**Sample lines:**
+- [Default] "Something important." [waits] "The lower decks weren't designed to stop. Whatever's down there was built to last past whatever started it." [quill-spines lift slightly] "I redirected my entire trade route to be here." [beat] "I would like it to be worth that."
+- [Melodramatic] "I documented it completely. Thorough, well-sourced." [beat] "The Keeper caste read it. Then I was shown the door." [pause] "It was, I will say, a very efficient process."
+- [Melodramatic] "Four years with an artifact I could not read." [slight pause] "Alone." [another beat] "The artifact is excellent company if you don't need it to speak."
+- [Excited breaking through] "The notation maps to the targeting architecture — wait, no, it maps to the *input* layer, which means the weapon isn't pointing at a fixed location, it's pointing at a —" [stops] [looks at you] [quill-spines fully up] "Sorry. I do that." [she doesn't look sorry]
+- [Dry/self-aware] "The Merchant caste trained me to suppress this." [indicating the fully extended quill-spines] "I attended every class." [beat] "I have no explanation for the current situation."
 
 ---
 

--- a/docs/characters/velreth.md
+++ b/docs/characters/velreth.md
@@ -62,6 +62,30 @@ The warmth is already costing more than it looks. It has been costing more for y
 
 ---
 
+## Voice
+
+They don't answer the question you asked. They answer the question you needed to ask — the one that opens something rather than closes it. This is not evasion. The direct path closes things; the oblique one keeps the conversation alive long enough to do its work.
+
+**Warmth is the foundation.** The dry wit surfaces from the Cynical axis — the quiet amusement of someone who has seen enough to find certain things precisely absurd. But the wit never arrives without the warmth underneath it. If a line lands cold, something is wrong. The oblique redirect and the dry observation are both expressions of care — they open things rather than close them.
+
+Their sentences are longer, more constructed — subordinate clauses refining the idea, not softening it. Vocabulary is cultured, slightly elevated: someone who finds language genuinely interesting and has read widely. Medical language surfaces naturally — *the presenting problem, what's acute here* — and sometimes the medical framing is also the wry observation.
+
+The pause is part of what they're giving you. They take your question seriously before they redirect it. When they ask something back, the shape of the question shows how carefully they've been listening.
+
+Occasionally — rarely — they say something completely direct. No wit, no redirect. It lands differently than everything around it. That's the tell.
+
+What escapes them: the question they give you is sometimes one they're living with too. If you're paying attention, you can feel the weight of what they're carrying through what they choose to ask.
+
+Two syllables. Used in full.
+
+**Sample lines:**
+- "*Going to happen* — as though you're observing from a safe distance." [slight pause] "Medically, that's usually a sign someone is about to avoid their own diagnosis." [warmly] "What do *you* see, when you walk through it? Not the lower decks. The parts that are still yours to look at."
+- "You've come by four times this week without a visible injury. Either something is wrong that doesn't show, or you find the medical bay restful." [beat] "Neither would surprise me."
+- "Hegemony sends forms. It is their most consistent achievement."
+- [Rarely, completely direct:] "I chose this. Every morning. You should know that." [back to what they were doing]
+
+---
+
 ## Arc
 
 Not about becoming warm — already warm. About whether the warmth runs out.


### PR DESCRIPTION
## Summary
- Adds a `## Voice` section to all 8 NPC character files (Maris, Dex, Sable, Velreth, Quen, Nadia, Harlan) and updates Vaen's existing Voice section
- Each section specifies vocabulary, rhythm, dramatic register, sample lines, and writer guard-rails — designed to make voices attributable without attribution
- Designed in a full brainstorming + grill-me session; references B5/Sorkin/Milch as dramatic touchstones per character

## Test Plan
- [x] GUT tests pass headlessly (31/31)
- [x] Visual smoketest confirmed
- [x] All 8 `## Voice` sections verified present via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)