### PR TITLE
feat: vertical slice Day 1 completable end-to-end

### DIFF
--- a/data/dialogue/dex.yarn
+++ b/data/dialogue/dex.yarn
@@ -1,6 +1,10 @@
 title: Dex
 ---
-<<jump Dex_FirstMeeting>>
+<<if get_flag("met_dex")>>
+    <<jump Dex_Casual>>
+<<else>>
+    <<jump Dex_FirstMeeting>>
+<<endif>>
 ===
 
 title: Dex_FirstMeeting
@@ -17,4 +21,9 @@ Dex: I'm Dex. I keep the systems from eating themselves. So far, so good.
     <<register sharp>>
     Dex: Long enough to know where the bodies are buried. Metaphorically. Probably.
 <<beat check_engineering>>
+===
+
+title: Dex_Casual
+---
+Dex: Back again. Nothing's exploded since you left, if that's what you're checking.
 ===

--- a/data/dialogue/quen.yarn
+++ b/data/dialogue/quen.yarn
@@ -1,0 +1,30 @@
+title: Quen
+---
+<<if get_flag("met_quen")>>
+    <<jump Quen_Casual>>
+<<else>>
+    <<jump Quen_FirstMeeting>>
+<<endif>>
+===
+
+title: Quen_FirstMeeting
+---
+Quen: So. The station has been assigned a commander.
+Quen: I have stood at this post through three such appointments. Each arrived with a mandate, a certainty, and a thorough unfamiliarity with what this place actually is.
+Quen: What Hegemony has given you, Commander, is a report. What I carry is fifteen years of what the report did not include.
+-> Tell me more. #register:curious
+    <<register curious>>
+    Quen: In time. There is an order to these things. You are not ready for more — I say that with neither condescension nor comfort. Simply fact.
+-> We'll figure it out together. #register:warm
+    <<register warm>>
+    Quen: A generous sentiment. [beat] I will remember you said it.
+-> Fine. #register:detached
+    <<register detached>>
+    Quen: [beat] Yes. That is often how it begins.
+<<beat quen_arrives>>
+===
+
+title: Quen_Casual
+---
+Quen: The corridors remain as I left them.
+===

--- a/scenes/areas/cantina.tscn
+++ b/scenes/areas/cantina.tscn
@@ -27,6 +27,9 @@ position = Vector2(120, 128)
 [node name="SableSpawn" type="Node2D" parent="." unique_id=1056703630]
 position = Vector2(240, 128)
 
+[node name="QuenSpawn" type="Node2D" parent="." unique_id=3174826059]
+position = Vector2(380, 128)
+
 [node name="EngineeringDoor" type="Area2D" parent="." unique_id=332849579]
 position = Vector2(472, 128)
 

--- a/scenes/ui/crafting_panel.tscn
+++ b/scenes/ui/crafting_panel.tscn
@@ -12,6 +12,7 @@ border_width_bottom = 1
 border_color = Color(0.4, 0.4, 0.6, 1)
 
 [node name="CraftingPanel" type="CanvasLayer"]
+process_mode = 3
 script = ExtResource("1")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]

--- a/scenes/ui/day_summary.tscn
+++ b/scenes/ui/day_summary.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://scripts/ui/day_summary.gd" id="1"]
 
 [node name="DaySummary" type="CanvasLayer"]
+process_mode = 3
 script = ExtResource("1")
 
 [node name="Panel" type="PanelContainer" parent="."]

--- a/scripts/autoload/day_manager.gd
+++ b/scripts/autoload/day_manager.gd
@@ -8,6 +8,7 @@ signal all_beats_done()
 var current_day: int = 1
 var _completed_beats: Array = []
 var _todays_beats: Array = []
+var _all_beats_emitted: bool = false
 
 # Arc beat definitions: array of { id, required, npc, flag_to_set }
 # Each entry in ARC_BEATS is the beat list for that day (1-indexed).
@@ -15,10 +16,10 @@ const ARC_BEATS: Dictionary = {
 	1: [
 		{ "id": "meet_maris", "required": true, "npc": "maris", "flag_to_set": "met_maris" },
 		{ "id": "check_engineering", "required": true, "npc": "dex", "flag_to_set": "met_dex" },
+		{ "id": "quen_arrives", "required": false, "npc": "quen", "flag_to_set": "met_quen" },
 	],
 	2: [
-		{ "id": "sable_arrives", "required": true, "npc": "sable", "flag_to_set": "met_sable" },
-		{ "id": "power_flicker", "required": true, "npc": "dex", "flag_to_set": "power_flicker_noticed" },
+		{ "id": "power_flicker", "required": false, "npc": "dex", "flag_to_set": "power_flicker_noticed" },
 	],
 	3: [
 		{ "id": "maris_food_trouble", "required": true, "npc": "maris", "flag_to_set": "maris_confided" },
@@ -44,7 +45,8 @@ const ARC_BEATS: Dictionary = {
 func reset() -> void:
 	current_day = 1
 	_completed_beats = []
-	_todays_beats = []
+	_todays_beats = ARC_BEATS.get(1, []).duplicate(true)
+	_all_beats_emitted = false
 
 func _ready() -> void:
 	reset()
@@ -52,6 +54,7 @@ func _ready() -> void:
 func _override_beats_for_test(beats: Array) -> void:
 	_todays_beats = beats.duplicate(true)
 	_completed_beats = []
+	_all_beats_emitted = false
 
 func get_todays_beats() -> Array:
 	return _todays_beats
@@ -60,11 +63,11 @@ func complete_beat(beat_id: String) -> void:
 	if not _completed_beats.has(beat_id):
 		_completed_beats.append(beat_id)
 		beat_completed.emit(beat_id)
-		# Set the flag on GameState
 		for beat in _todays_beats:
 			if beat["id"] == beat_id and beat.get("flag_to_set", "") != "":
 				GameState.set_flag(beat["flag_to_set"], true)
-		if is_day_complete():
+		if is_day_complete() and not _all_beats_emitted:
+			_all_beats_emitted = true
 			all_beats_done.emit()
 
 func is_beat_complete(beat_id: String) -> bool:
@@ -81,4 +84,5 @@ func advance_day() -> void:
 	current_day += 1
 	_completed_beats = []
 	_todays_beats = ARC_BEATS.get(current_day, []).duplicate(true)
+	_all_beats_emitted = false
 	day_ended.emit(finished_day)

--- a/scripts/autoload/game_state.gd
+++ b/scripts/autoload/game_state.gd
@@ -19,6 +19,12 @@ const BACKGROUND_BONUSES = {
 	"drifter": { "energy_cells": 3 }
 }
 
+const ARRIVAL_KIT: Dictionary = {
+	"rations": 1,
+	"parts": 1,
+	"energy_cells": 1,
+}
+
 func reset() -> void:
 	player_name = ""
 	player_background = ""
@@ -37,6 +43,8 @@ func set_player_identity(name: String, background: String, appearance: int) -> v
 	player_appearance = appearance
 
 func apply_background_bonus(background: String) -> void:
+	for resource_id in ARRIVAL_KIT:
+		add_resource(resource_id, ARRIVAL_KIT[resource_id])
 	if not BACKGROUND_BONUSES.has(background):
 		return
 	for resource_id in BACKGROUND_BONUSES[background]:

--- a/scripts/characters/quen.gd
+++ b/scripts/characters/quen.gd
@@ -1,0 +1,11 @@
+# scripts/characters/quen.gd
+extends "res://scripts/characters/npc_base.gd"
+
+func _ready() -> void:
+	super()
+	npc_id = "quen"
+	display_name = "Quen"
+	$AnimatedSprite2D.modulate = Color(0.85, 0.75, 1.0)  # lavender
+
+func get_dialogue_node() -> String:
+	return "Quen"

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -10,7 +10,7 @@ const AREA_SCENES = {
 
 const NPC_SPAWN_AREAS = {
 	"maris": "cantina",
-	"sable": "cantina",
+	"quen": "cantina",
 	"dex": "engineering",
 }
 
@@ -55,7 +55,7 @@ func _setup_dialogue_runner() -> void:
 func _spawn_npcs() -> void:
 	var npc_scripts = {
 		"maris": "res://scripts/characters/maris.gd",
-		"sable": "res://scripts/characters/sable.gd",
+		"quen": "res://scripts/characters/quen.gd",
 		"dex": "res://scripts/characters/dex.gd",
 	}
 	for npc_id in npc_scripts:

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -44,6 +44,10 @@ func _ready() -> void:
 	go_to_area("cantina")
 	get_viewport().gui_release_focus()
 
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
+		get_tree().quit()
+
 func _setup_dialogue_runner() -> void:
 	var runners := get_tree().get_nodes_in_group("dialogue_runner")
 	if runners.is_empty():

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -117,6 +117,8 @@ func _on_day_ended(day: int) -> void:
 	else:
 		if DayManager.current_day == 7:
 			arc_events.trigger_final_choice()
+		else:
+			show_hud_message("Day %d begins." % DayManager.current_day)
 
 func _on_all_beats_done() -> void:
 	show_hud_message("All story beats complete. Rest at your bunk in Quarters.")

--- a/scripts/ui/character_creation.gd
+++ b/scripts/ui/character_creation.gd
@@ -19,8 +19,15 @@ func _ready() -> void:
 		appearance_picker.get_child(i).pressed.connect(_set_appearance.bind(i))
 	for i in background_picker.get_child_count():
 		background_picker.get_child(i).pressed.connect(_set_background.bind(i))
+	# Pre-select defaults so only a name is required
+	_set_appearance(0)
+	_set_background(0)
 	name_input.grab_focus()
 	_update_start_btn()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
+		get_tree().quit()
 
 func _set_appearance(idx: int) -> void:
 	_selected_appearance = idx

--- a/scripts/ui/crafting_panel.gd
+++ b/scripts/ui/crafting_panel.gd
@@ -5,7 +5,6 @@ extends CanvasLayer
 @onready var close_btn: Button = $PanelContainer/VBoxContainer/CloseButton
 
 func _ready() -> void:
-	process_mode = Node.PROCESS_MODE_ALWAYS
 	hide()
 	close_btn.pressed.connect(hide)
 

--- a/scripts/ui/crafting_panel.gd
+++ b/scripts/ui/crafting_panel.gd
@@ -5,6 +5,7 @@ extends CanvasLayer
 @onready var close_btn: Button = $PanelContainer/VBoxContainer/CloseButton
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	hide()
 	close_btn.pressed.connect(hide)
 

--- a/scripts/ui/crafting_panel.gd
+++ b/scripts/ui/crafting_panel.gd
@@ -8,6 +8,11 @@ func _ready() -> void:
 	hide()
 	close_btn.pressed.connect(hide)
 
+func _unhandled_input(event: InputEvent) -> void:
+	if visible and event.is_action_pressed("ui_cancel"):
+		hide()
+		get_viewport().set_input_as_handled()
+
 func open() -> void:
 	_build_recipe_list()
 	show()

--- a/scripts/ui/crafting_panel.gd
+++ b/scripts/ui/crafting_panel.gd
@@ -4,46 +4,84 @@ extends CanvasLayer
 @onready var recipes_container: VBoxContainer = $PanelContainer/VBoxContainer/RecipesContainer
 @onready var close_btn: Button = $PanelContainer/VBoxContainer/CloseButton
 
+var _recipe_ids: Array = []
+
 func _ready() -> void:
 	hide()
 	close_btn.pressed.connect(hide)
 
 func _unhandled_input(event: InputEvent) -> void:
-	if visible and event.is_action_pressed("ui_cancel"):
+	if not visible:
+		return
+	if event.is_action_pressed("ui_cancel"):
 		hide()
 		get_viewport().set_input_as_handled()
+		return
+	var buttons := recipes_container.get_children()
+	if event.is_action_pressed("ui_up"):
+		_move_focus(buttons, -1)
+		get_viewport().set_input_as_handled()
+	elif event.is_action_pressed("ui_down"):
+		_move_focus(buttons, 1)
+		get_viewport().set_input_as_handled()
+	elif event.is_action_pressed("ui_accept") or event.is_action_pressed("ui_select"):
+		var focused := get_viewport().gui_get_focus_owner()
+		if focused and focused.get_parent() == recipes_container and not focused.disabled:
+			focused.emit_signal("pressed")
+			get_viewport().set_input_as_handled()
+	elif event is InputEventKey and event.pressed:
+		for i in range(min(9, buttons.size())):
+			if event.physical_keycode == KEY_1 + i:
+				if not buttons[i].disabled:
+					buttons[i].emit_signal("pressed")
+				get_viewport().set_input_as_handled()
+				return
 
 func open() -> void:
 	_build_recipe_list()
 	show()
 
 func _build_recipe_list() -> void:
+	_recipe_ids = []
 	for child in recipes_container.get_children():
 		child.queue_free()
 
+	var idx := 0
 	for recipe_id in CraftingSystem.get_all_recipes():
 		if not CraftingSystem.is_recipe_available(recipe_id):
 			continue
-		var hbox = HBoxContainer.new()
-		var lbl = Label.new()
-		lbl.add_theme_font_override("font", load("res://data/fonts/m5x7.tres"))
-		lbl.add_theme_font_size_override("font_size", 16)
+		idx += 1
+		_recipe_ids.append(recipe_id)
 		var recipe = CraftingSystem.get_all_recipes()[recipe_id]
 		var cost_parts = []
 		for input in recipe["inputs"]:
-			cost_parts.append("%d %s" % [input["qty"], input["id"]])
-		lbl.text = "%s  (%s)" % [recipe_id.replace("_", " ").capitalize(), ", ".join(cost_parts)]
-		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		var btn = Button.new()
+			cost_parts.append("%d %s" % [input["qty"], input["id"].replace("_", " ")])
+		var can = CraftingSystem.can_craft(recipe_id)
+		var label = "[%d] %s  (%s)" % [idx, recipe_id.replace("_", " ").capitalize(), ", ".join(cost_parts)]
+		if not can:
+			label += "  —  need more"
+		var btn := Button.new()
+		btn.text = label
 		btn.add_theme_font_override("font", load("res://data/fonts/m5x7.tres"))
-		btn.add_theme_font_size_override("font_size", 16)
-		btn.text = "Craft"
-		btn.disabled = not CraftingSystem.can_craft(recipe_id)
+		btn.add_theme_font_size_override("font_size", 13)
+		btn.disabled = not can
 		btn.pressed.connect(_craft.bind(recipe_id))
-		hbox.add_child(lbl)
-		hbox.add_child(btn)
-		recipes_container.add_child(hbox)
+		recipes_container.add_child(btn)
+
+	# Focus first craftable button
+	for btn in recipes_container.get_children():
+		if not btn.disabled:
+			btn.grab_focus()
+			break
 
 func _craft(recipe_id: String) -> void:
 	CraftingSystem.craft(recipe_id)
 	_build_recipe_list()
+
+func _move_focus(buttons: Array, direction: int) -> void:
+	var focused := get_viewport().gui_get_focus_owner()
+	var current := buttons.find(focused)
+	if current == -1:
+		current = 0
+	var next := wrapi(current + direction, 0, buttons.size())
+	buttons[next].grab_focus()

--- a/scripts/ui/day_summary.gd
+++ b/scripts/ui/day_summary.gd
@@ -6,6 +6,7 @@ extends CanvasLayer
 @onready var rest_btn: Button = $Panel/VBox/RestButton
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	hide()
 	rest_btn.pressed.connect(_on_rest)
 

--- a/scripts/ui/day_summary.gd
+++ b/scripts/ui/day_summary.gd
@@ -6,7 +6,6 @@ extends CanvasLayer
 @onready var rest_btn: Button = $Panel/VBox/RestButton
 
 func _ready() -> void:
-	process_mode = Node.PROCESS_MODE_ALWAYS
 	hide()
 	rest_btn.pressed.connect(_on_rest)
 

--- a/scripts/ui/day_summary.gd
+++ b/scripts/ui/day_summary.gd
@@ -9,6 +9,13 @@ func _ready() -> void:
 	hide()
 	rest_btn.pressed.connect(_on_rest)
 
+func _unhandled_input(event: InputEvent) -> void:
+	if not visible:
+		return
+	if event.is_action_pressed("ui_accept") or event.is_action_pressed("ui_select"):
+		_on_rest()
+		get_viewport().set_input_as_handled()
+
 func show_summary() -> void:
 	day_lbl.text = "End of Day %d" % DayManager.current_day
 	for child in events_container.get_children():
@@ -17,8 +24,11 @@ func show_summary() -> void:
 		if DayManager.is_beat_complete(beat["id"]):
 			var lbl = Label.new()
 			lbl.text = "✓ %s" % beat["id"].replace("_", " ").capitalize()
+			lbl.add_theme_font_override("font", load("res://data/fonts/m5x7.tres"))
+			lbl.add_theme_font_size_override("font_size", 13)
 			events_container.add_child(lbl)
 	show()
+	rest_btn.grab_focus()
 
 func _on_rest() -> void:
 	hide()

--- a/scripts/ui/dialogue_box.gd
+++ b/scripts/ui/dialogue_box.gd
@@ -51,6 +51,17 @@ func _process(delta: float) -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if not visible:
 		return
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		match _state:
+			_State.TYPEWRITING:
+				_dialogue_text.visible_characters = -1
+				_typewriter_timer = 9999.0
+				_state = _State.COMPLETE
+			_State.COMPLETE:
+				_state = _State.IDLE
+				_line_advance_requested.emit()
+		get_viewport().set_input_as_handled()
+		return
 	if event.is_action_pressed("ui_accept") or event.is_action_pressed("ui_select"):
 		match _state:
 			_State.TYPEWRITING:

--- a/scripts/ui/dialogue_box.gd
+++ b/scripts/ui/dialogue_box.gd
@@ -35,6 +35,7 @@ var _typewriter_target: int = 0
 var _full_text: String = ""
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	add_to_group("dialogue_box")
 	_player_portrait.texture = _make_atlas(PLAYER_PORTRAIT_INDEX)
 	hide()

--- a/scripts/ui/hud.gd
+++ b/scripts/ui/hud.gd
@@ -38,6 +38,7 @@ func _refresh_beats(_beat_id) -> void:
 
 func _on_day_ended(_day) -> void:
 	day_lbl.text = "Day %d" % DayManager.current_day
+	_refresh_beats("")
 
 func show_message(text: String) -> void:
 	message_lbl.text = text

--- a/tests/test_day_manager.gd
+++ b/tests/test_day_manager.gd
@@ -8,8 +8,8 @@ func before_each():
 func test_starts_on_day_one():
 	assert_eq(DayManager.current_day, 1)
 
-func test_beats_empty_on_reset():
-	assert_eq(DayManager.get_todays_beats().size(), 0)
+func test_reset_loads_day_one_beats():
+	assert_eq(DayManager.get_todays_beats().size(), 3)
 
 func test_complete_beat():
 	DayManager.reset()
@@ -47,3 +47,16 @@ func test_advance_day_clears_completed_beats():
 	DayManager.complete_beat("beat_a")
 	DayManager.advance_day()
 	assert_false(DayManager.is_beat_complete("beat_a"))
+
+func test_all_beats_done_fires_once():
+	DayManager._override_beats_for_test([
+		{ "id": "beat_required", "required": true },
+		{ "id": "beat_optional", "required": false }
+	])
+	var count = [0]
+	var cb = func(): count[0] += 1
+	DayManager.all_beats_done.connect(cb)
+	DayManager.complete_beat("beat_required")   # day is now complete → should emit once
+	DayManager.complete_beat("beat_optional")   # day still complete → should NOT emit again
+	DayManager.all_beats_done.disconnect(cb)
+	assert_eq(count[0], 1)

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -49,17 +49,25 @@ func test_set_player_identity():
 func test_engineer_background_starts_with_parts():
 	GameState.reset()
 	GameState.apply_background_bonus("engineer")
-	assert_eq(GameState.get_resource("parts"), 3)
+	assert_eq(GameState.get_resource("parts"), 4)
 
 func test_medic_background_starts_with_rations():
 	GameState.reset()
 	GameState.apply_background_bonus("medic")
-	assert_eq(GameState.get_resource("rations"), 3)
+	assert_eq(GameState.get_resource("rations"), 4)
 
 func test_drifter_background_starts_with_energy_cells():
 	GameState.reset()
 	GameState.apply_background_bonus("drifter")
-	assert_eq(GameState.get_resource("energy_cells"), 3)
+	assert_eq(GameState.get_resource("energy_cells"), 4)
+
+func test_arrival_kit_applied():
+	for background in ["engineer", "medic", "drifter"]:
+		GameState.reset()
+		GameState.apply_background_bonus(background)
+		assert_gte(GameState.get_resource("rations"), 1, "rations >= 1 for %s" % background)
+		assert_gte(GameState.get_resource("parts"), 1, "parts >= 1 for %s" % background)
+		assert_gte(GameState.get_resource("energy_cells"), 1, "energy_cells >= 1 for %s" % background)
 
 func test_npc_flag_history():
 	GameState.reset()


### PR DESCRIPTION
## Summary
- Adds Quen as a new NPC (replaces Sable) with first-meeting and casual dialogue, completing the Day 1 beat roster
- Implements arrival kit + background bonus resources, DayManager arc beats with `all_beats_done` guard, and full Day 1 → Day 2 transition
- Fixes all blocking UI bugs: crafting panel rebuilt with keyboard navigation (1–9/↑↓/Enter/Escape), day summary auto-focuses Rest button with Enter support, all UI panels set to `process_mode = 3` in scene files, character creation pre-selects defaults so only a name is required, Escape quits from anywhere

## Test Plan
- [ ] GUT tests pass headlessly (33/33)
- [ ] Character creation: type name, press Enter → game starts
- [ ] Talk to Maris → beat completes; talk to Dex → beat completes; HUD shows "Rest at your bunk"
- [ ] Optional: talk to Quen → `quen_arrives` beat completes, doesn't block sleep
- [ ] Open crafting in Engineering: keyboard 1/2/3 selects recipes, ↑↓ navigates, Enter crafts, Escape closes
- [ ] Rest at bunk → Day Summary appears with completed beats; Enter or click Rest → "Day 2 begins." HUD message
- [ ] Day 2: Dex gives casual dialogue; Quen (if met) gives casual dialogue
- [ ] Escape quits game from any screen

Closes #41