### PR TITLE
docs: rename Commander → Superintendent across all docs and dialogue

### DIFF
--- a/data/dialogue/quen.yarn
+++ b/data/dialogue/quen.yarn
@@ -9,9 +9,9 @@ title: Quen
 
 title: Quen_FirstMeeting
 ---
-Quen: So. The station has been assigned a commander.
+Quen: So. The station has been assigned a superintendent.
 Quen: I have stood at this post through three such appointments. Each arrived with a mandate, a certainty, and a thorough unfamiliarity with what this place actually is.
-Quen: What Hegemony has given you, Commander, is a report. What I carry is fifteen years of what the report did not include.
+Quen: What Hegemony has given you, Superintendent, is a report. What I carry is fifteen years of what the report did not include.
 -> Tell me more. #register:curious
     <<register curious>>
     Quen: In time. There is an order to these things. You are not ready for more — I say that with neither condescension nor comfort. Simply fact.

--- a/data/dialogue/velreth.yarn
+++ b/data/dialogue/velreth.yarn
@@ -12,7 +12,7 @@ title: Velreth_FirstMeeting
 Velreth: You are not injured. That is, statistically speaking, the least common reason people find their way here on a first day.
 -> I wanted to introduce myself. #register:warm
     <<register warm>>
-    Velreth: A reasonable instinct. [beat] Most commanders wait until something breaks before they remember the med bay exists.
+    Velreth: A reasonable instinct. [beat] Most superintendents wait until something breaks before they remember the med bay exists.
 -> Just getting my bearings. #register:curious
     <<register curious>>
     Velreth: A useful exercise. The station has a way of disorienting people — not just physically. I find it helps to know where the medical bay is. In case the bearings don't hold.

--- a/docs/characters/dex.md
+++ b/docs/characters/dex.md
@@ -63,7 +63,7 @@ His vocabulary is systems: *load-bearing, rated capacity, structural fault.* He 
 
 Short sentences for hard truths. Longer when something engages him — the technical run-on is the tell. He'll explain why a repair is wrong for three sentences and halfway through you realize he's talking about something else entirely. The curiosity cracks the guard open. He doesn't notice when it happens.
 
-Numbers carry emotion he won't name. *Four years. Six commanders.* He doesn't explain what they mean. You do the math.
+Numbers carry emotion he won't name. *Four years. Six chiefs.* He doesn't explain what they mean. You do the math.
 
 What escapes him: the sentence that arrives before he decided to say it. The technical explanation that runs long. The line that lands while he's already through the door. He can't stop telling the truth. He just stopped caring about the aftermath.
 
@@ -72,7 +72,7 @@ He does not say: *I think, I feel, I hope.* He doesn't soften. He doesn't check 
 **Sample lines:**
 - "Power systems in the lower decks don't map to the schematics. Four years they haven't mapped. Whatever's running down there, we're not supplying it." [moves to next panel] "That's the variable I'd actually think about."
 - "That's not a repair. That's a note to yourself."
-- "Six commanders. First one to tell Hegemony no." [goes back inside — door stays open]
+- "Six chiefs. First one to tell Hegemony no." [goes back inside — door stays open]
 - He's under the deck plating a long time, light moving slow along the fracture line. "Whoever patched this the first time knew it wouldn't hold. Did it anyway." [beat] "That tells you something." He doesn't say what.
 
 ## Arc
@@ -91,7 +91,7 @@ He is the first person on the station who *could* understand what the weapon is 
 
 **Maris:** Philosophical tension, not personal. She believes in the station as something worth building; he believes in it as something worth maintaining. They respect each other. They disagree about what respect requires. Neither is wrong, which is why it hasn't resolved in seven years. When she told him about the Vess reassignment threat, she told him directly and left the room. That was respect.
 
-**The commander:** Six commanders. First one to tell Hegemony no. He went back inside and left the bay door open. That's not warmth — it's the possibility of what might come through it.
+**The Superintendent:** Six chiefs. First one to tell Hegemony no. He went back inside and left the bay door open. That's not warmth — it's the possibility of what might come through it.
 
 ---
 

--- a/docs/characters/harlan.md
+++ b/docs/characters/harlan.md
@@ -27,9 +27,9 @@ The face of someone who has delivered difficult news many times and learned how 
 
 ## Background
 
-He is not a fixer. He is someone the commander genuinely respects — a mentor or former colleague who believes in Hegemony's mission and means it. The threat he represents is not institutional pressure. It is the cost of choosing against someone you care about.
+He is not a fixer. He is someone the superintendent genuinely respects — a mentor or former colleague who believes in Hegemony's mission and means it. The threat he represents is not institutional pressure. It is the cost of choosing against someone you care about.
 
-Sending him personally was not routine. Someone at Hegemony decided this required a face the commander trusts. Harlan came because he chose to. He could have sent someone else. That fact is the closest thing he will offer to *I still believe in you.*
+Sending him personally was not routine. Someone at Hegemony decided this required a face the superintendent trusts. Harlan came because he chose to. He could have sent someone else. That fact is the closest thing he will offer to *I still believe in you.*
 
 ---
 
@@ -37,13 +37,13 @@ Sending him personally was not routine. Someone at Hegemony decided this require
 
 He knows about the buried survey — a significant archaeological asset in the lower decks, worth controlling, worth the quiet acquisition. He does not know the station is a weapon.
 
-When the commander tells him the full truth, he takes a moment. Then he asks for it anyway. He believes Hegemony is the right hands for something this dangerous. That belief is sincere. It is also the thing that makes him impossible to reach.
+When the superintendent tells him the full truth, he takes a moment. Then he asks for it anyway. He believes Hegemony is the right hands for something this dangerous. That belief is sincere. It is also the thing that makes him impossible to reach.
 
 ---
 
 ## The Crack
 
-Somewhere in the Act 3 conversation, he sees it the way the commander sees it — the scale of what was buried there, what it means if the weapon activates, what Hegemony will actually do with a targeting system pointed at a populated world. The crack appears and heals in the same scene. He doesn't change. But the player saw that he could have.
+Somewhere in the Act 3 conversation, he sees it the way the superintendent sees it — the scale of what was buried there, what it means if the weapon activates, what Hegemony will actually do with a targeting system pointed at a populated world. The crack appears and heals in the same scene. He doesn't change. But the player saw that he could have.
 
 ---
 
@@ -51,7 +51,7 @@ Somewhere in the Act 3 conversation, he sees it the way the commander sees it �
 
 Harlan does not arrive empty-handed. Hegemony's buried survey found a shutdown mechanism — a control interface for the weapon, documented but not understood at the time. Hegemony has spent years quietly studying it. By Act 3, they understand it well enough to use it.
 
-Harlan holds the only known way to stop a weapon that will otherwise destroy the station and everyone on it. He didn't come to negotiate. He came knowing he held the only card that mattered — and genuinely believing that using it saves the people he cares about, including the commander. He is not wrong about that. He is also getting everything Hegemony sent him for. Both things are true.
+Harlan holds the only known way to stop a weapon that will otherwise destroy the station and everyone on it. He didn't come to negotiate. He came knowing he held the only card that mattered — and genuinely believing that using it saves the people he cares about, including the superintendent. He is not wrong about that. He is also getting everything Hegemony sent him for. Both things are true.
 
 ---
 
@@ -59,7 +59,7 @@ Harlan holds the only known way to stop a weapon that will otherwise destroy the
 
 The sincerity is not a weapon. He does not deploy warmth strategically — he is warm, structurally, the way some people are. The Hopeful axis means he has kept faith with institutions across a career that has shown him exactly what those institutions are. He is not naive. He has made peace with the gap between what Hegemony says and what it does, and he has decided the mission is still worth it.
 
-The Bitter axis lives quietly. He has delivered these conversations before. He knows the shape of what he's asking. He knows the commander will see the cost of it. He came anyway.
+The Bitter axis lives quietly. He has delivered these conversations before. He knows the shape of what he's asking. He knows the superintendent will see the cost of it. He came anyway.
 
 The thing that makes him impossible to reach is not the sincerity alone — it's that he's already done the math. He arrived at his position through genuine reasoning and he has held it long enough that it's settled. A crack in a scene is not enough to reopen a decision you made twenty years ago.
 
@@ -87,19 +87,19 @@ He does not: rush, apply pressure through coldness, use distance as a tool. He c
 
 ## Arc
 
-One scene. Everything he is gets compressed into it. The question is not whether Harlan will change — he won't. The question is whether the commander, and the player, can see the person who might have, and understand that this specific person, with this specific warmth and this specific faith, is asking for the thing he's asking for.
+One scene. Everything he is gets compressed into it. The question is not whether Harlan will change — he won't. The question is whether the superintendent, and the player, can see the person who might have, and understand that this specific person, with this specific warmth and this specific faith, is asking for the thing he's asking for.
 
 ---
 
-## The Commander
+## The Superintendent
 
-By background, the relationship takes a different form — but all three share the same structure: someone who believed in the commander before the station, who comes carrying that belief as a credential, and who means it.
+By background, the relationship takes a different form — but all three share the same structure: someone who believed in the superintendent before the station, who comes carrying that belief as a credential, and who means it.
 
-- **Engineer:** A senior Hegemony surveyor who recognized the commander's technical ability early and brought them into increasingly significant assessments. Their arrival is the hardest version: someone who taught the commander to see clearly, now asking them to look away.
+- **Engineer:** A senior Hegemony surveyor who recognized the superintendent's technical ability early and brought them into increasingly significant assessments. Their arrival is the hardest version: someone who taught the superintendent to see clearly, now asking them to look away.
 
 - **Medic:** A Hegemony operations coordinator who ran the humanitarian framing. They believe in it sincerely — they have seen Hegemony's support do genuine good, and they have learned not to look too closely at the cost. Not cynical. Practiced.
 
-- **Drifter:** Someone who offered stability at a moment when stability felt impossible. The arrangement was transactional — a report in exchange for a footing — but the relationship became real. They kept their end. They are here to collect the commander's.
+- **Drifter:** Someone who offered stability at a moment when stability felt impossible. The arrangement was transactional — a report in exchange for a footing — but the relationship became real. They kept their end. They are here to collect the superintendent's.
 
 What they all share: they are not villains. They believe in what they're asking for. That is what makes the scene work.
 

--- a/docs/characters/maris.md
+++ b/docs/characters/maris.md
@@ -85,9 +85,9 @@ She has no one to aim the anger at. The officer was censured. The representative
 
 **She will not accept the settlement.** Not because she wants Hegemony to suffer. Because accepting it would mean the record is complete, and the record is not complete. Some things should not be resolved, because resolving them would be a lie about what happened. The file stays open. The record keeps knowing.
 
-**She reads fast and accurately.** She doesn't explain her reads. She told the commander about Cael on day three — not to warn them, not to bond — because they needed to know, delivered as fact, and she went back to work. She told Dex about his potential reassignment directly and left the room because staying with nothing to say was just another thing he'd have to manage.
+**She reads fast and accurately.** She doesn't explain her reads. She told the superintendent about Cael on day three — not to warn them, not to bond — because they needed to know, delivered as fact, and she went back to work. She told Dex about his potential reassignment directly and left the room because staying with nothing to say was just another thing he'd have to manage.
 
-**She is warm in the way that stays present with difficulty, not in the way that softens it.** After Renn leaves — after the hardest day she's had in years — she goes back to the dinner prep. She corrects the commander cleanly: *you should have told me. I don't need protection from it. I need to be ready.* Then she lets them stay and help with the prep.
+**She is warm in the way that stays present with difficulty, not in the way that softens it.** After Renn leaves — after the hardest day she's had in years — she goes back to the dinner prep. She corrects the superintendent cleanly: *you should have told me. I don't need protection from it. I need to be ready.* Then she lets them stay and help with the prep.
 
 ---
 
@@ -119,7 +119,7 @@ She does not say: *I think, I feel, I guess, maybe.* She doesn't soften entry. S
 
 Not about becoming hopeful — she already is. About whether the bitterness eventually erodes the warmth and hope that have survived alongside it for seven years.
 
-The specific pressure: the commander is Hegemony-sent. She chose to be warm to them anyway. That choice is load-bearing. When the weapon activates and the station is no longer a safe distance from institutional power, the question becomes whether she can hold the forward-facing orientation when it's pointed directly at the thing that killed Cael.
+The specific pressure: the superintendent is Hegemony-sent. She chose to be warm to them anyway. That choice is load-bearing. When the weapon activates and the station is no longer a safe distance from institutional power, the question becomes whether she can hold the forward-facing orientation when it's pointed directly at the thing that killed Cael.
 
 The quieter arc: she is fond of Sable and has rationed the investment because she's watched Sable leave before. She knows the price of letting something matter. Whether she can let herself care fully — not just warmly but with real cost — runs underneath the main arc.
 
@@ -127,13 +127,13 @@ The quieter arc: she is fond of Sable and has rationed the investment because sh
 
 ## Relationships
 
-**Velreth:** The most lived-in friendship on the station. Two warm people, opposite on every other axis — Maris is Hopeful/Bitter, Velreth is Cynical/Curious. They have been each other's counterweight for years before the commander arrives. Maris keeps the future open when Velreth can't; Velreth keeps asking questions when Maris doesn't want to know. Neither needs the other to be different.
+**Velreth:** The most lived-in friendship on the station. Two warm people, opposite on every other axis — Maris is Hopeful/Bitter, Velreth is Cynical/Curious. They have been each other's counterweight for years before the superintendent arrives. Maris keeps the future open when Velreth can't; Velreth keeps asking questions when Maris doesn't want to know. Neither needs the other to be different.
 
 **Dex:** Philosophical tension, not personal. She believes in the station as something worth building; he believes in it as something worth maintaining. They respect each other. They disagree about what respect requires. Neither is wrong, which is why it hasn't resolved in seven years. When she told him about the reassignment threat, she told him directly and left the room. That was respect.
 
 **Sable:** Fond, holds back. Maris has learned to hold it at a slight distance — she's watched Sable leave before. The warmth is real; the investment is rationed. For Sable, Maris is the closest thing to a home she's had, which is exactly why she hasn't left yet this time.
 
-**The commander:** She chose to be warm to them despite knowing they're Hegemony-sent. She corrected them when they withheld the Renn information — not in anger, in clarity: *I don't need protection from it. I need to be ready.* The relationship is real and it is also, for her, a conscious choice she has to keep making.
+**The superintendent:** She chose to be warm to them despite knowing they're Hegemony-sent. She corrected them when they withheld the Renn information — not in anger, in clarity: *I don't need protection from it. I need to be ready.* The relationship is real and it is also, for her, a conscious choice she has to keep making.
 
 ---
 
@@ -141,7 +141,7 @@ The quieter arc: she is fond of Sable and has rationed the investment because sh
 
 The lower decks are sealed. Something happened. She has been here seven years and made a deliberate choice not to pull that thread. She knows what it costs to know certain things, and she has decided this one isn't hers to carry.
 
-When the commander begins investigating, that choice becomes harder to maintain.
+When the superintendent begins investigating, that choice becomes harder to maintain.
 
 ---
 

--- a/docs/characters/npcs.md
+++ b/docs/characters/npcs.md
@@ -15,16 +15,18 @@ This is the canonical reference for all named characters in Outpost Nova. It cov
 
 ---
 
-## The Commander (Player Character)
+## The Superintendent (Player Character)
 
 **Age:** 31
 **Species:** Human
 **Gender:** Player-selectable
 **Appearance:** TBD — resolved at character creation (sprite selection)
 
+The crew's informal address for the Superintendent is **Chief** — earned over time, not given on arrival. Maris is the first crew member to make the switch; Quen is the last.
+
 **Background:** Arrived as Hegemony Combine's appointed station manager. Carries general institutional distrust of Hegemony — earned through experience during and after the war, not specific intelligence about the ruins. Saw real action in the final years of the Fracture, likely at 18-20 years old. Five years of post-war Hegemony work before this assignment.
 
-The ruins are a genuine discovery. The commander did not know about the buried survey before arrival.
+The ruins are a genuine discovery. The superintendent did not know about the buried survey before arrival.
 
 **Backgrounds (player choice):**
 
@@ -74,6 +76,8 @@ Informal trader and information broker. Connects easily, leaves before it gets c
 
 One of the last Thessari. Rebuilt warmth from scratch after displacement, with no culture to back it. Intellectual, cultured, oblique.
 
+**Employment model:** Velreth holds no station contract and receives no payroll. The arrangement is informal and unspoken: the station provides a berth and meals; Velreth provides medical care. Neither party has formalized it. (Reference: Doc Cochrane in *Deadwood*.)
+
 → Full reference: `docs/characters/velreth.md`
 
 ---
@@ -83,6 +87,8 @@ One of the last Thessari. Rebuilt warmth from scratch after displacement, with n
 **Age:** Unknown (15+ years on station) | **Species:** Maevet (Unbound) | **Pronouns:** It/its | **Profile:** Detached / Warm / Bitter | **On station:** 15+ years
 
 The station's oldest presence. Chose to stay when Maevet don't stay; sealed the Derelict door and stopped asking questions. Speaks in grand lyrical registers. The silence is the wound.
+
+**Contract:** Quen's arrangement is with the station (a legacy contract), not with Hegemony Combine directly. In Act 3, Harlan has no employment lever over Quen — the relationship between Quen and Hegemony runs through the station, not through him.
 
 → Full reference: `docs/characters/quen.md`
 
@@ -106,7 +112,7 @@ Federation intelligence operative under journalist cover — and the journalism 
 
 **Age:** Late 30s (Keth equivalent) | **Species:** Keth | **Pronouns:** She/her | **Profile:** Hopeful / Detached / Curious | **On station:** Act 2 arrival
 
-Merchant caste exile, explorer by temperament. Has been monitoring Builder signal patterns for years; redirected to this station when the commander triggered the weapon's charging sequence. Carries a physical artifact from a secondary Builder ruins site — unreadable until the weapon's structure resolves it. Presents as a trader. Does not immediately say why she came.
+Merchant caste exile, explorer by temperament. Has been monitoring Builder signal patterns for years; redirected to this station when the superintendent triggered the weapon's charging sequence. Carries a physical artifact from a secondary Builder ruins site — unreadable until the weapon's structure resolves it. Presents as a trader. Does not immediately say why she came.
 
 → Full reference: `docs/characters/vaen.md`
 
@@ -118,7 +124,7 @@ Merchant caste exile, explorer by temperament. Has been monitoring Builder signa
 
 **Age:** 50s | **Species:** Human | **Profile:** Hopeful / Warm / Bitter | **Title:** Senior Operations Director, Frontier Acquisitions | **On station:** Act 3 arrival
 
-Not a fixer — someone the commander genuinely respects and trusts. Holds the only known weapon shutdown mechanism. Believes in what he's asking for. That's what makes the scene work.
+Not a fixer — someone the superintendent genuinely respects and trusts. Holds the only known weapon shutdown mechanism. Believes in what he's asking for. That's what makes the scene work.
 
 → Full reference: `docs/characters/harlan.md`
 
@@ -177,4 +183,4 @@ Feathered theropod. Bipedal, digitigrade. Three-fingered hands, no wings. Indivi
 - **Derelict incident specifics** — what Quen saw, story beat not design decision
 - **Keth civilization names** (first and second ancient civs) — deferred
 - **Recruitable Derelict survivors** (2-3 characters) — separate design session
-- **Commander appearance options** — resolved at character creation art time
+- **Superintendent appearance options** — resolved at character creation art time

--- a/docs/characters/quen.md
+++ b/docs/characters/quen.md
@@ -84,9 +84,11 @@ Sentences about the lower decks don't finish.
 
 ## Arc
 
-In Act 1: friction with the commander. Its authority is station-native; the commander's is Hegemony-issued. It has watched Hegemony representatives come and go. The specific wariness it holds for the commander is different from that pattern — and it knows the difference.
+In Act 1: friction with the superintendent. Its authority is station-native; the superintendent's is Hegemony-issued. It has watched Hegemony representatives come and go. The specific wariness it holds for the superintendent is different from that pattern — and it knows the difference.
 
 In Acts 2–3: it must decide where its loyalty lies. The station it stayed for. The crew it chose. The long memory it wounded to protect them. When the weapon activates and what Quen sealed begins to come apart, the question is whether the choice to stay meant the choice to stay for this too.
+
+Quen's contract is with the station (a legacy arrangement predating the current superintendent), not with Hegemony Combine directly. In Act 3, Harlan has no employment lever over Quen — the relationship between Quen and Hegemony runs through the station, not through him.
 
 ---
 
@@ -100,7 +102,7 @@ In Acts 2–3: it must decide where its loyalty lies. The station it stayed for.
 
 **Velreth:** Wary warmth. Velreth treated crew who came back from the lower decks before the sealing. There was one moment — a medical consultation that touched close to what Quen knows — where both of them chose not to ask the question that was right there. They have never spoken of it. The relationship lives in that shared not-asking.
 
-**The commander:** Friction in Act 1. Its authority over restricted access is station-native and absolute; the commander's Hegemony mandate is precisely the kind of institutional claim it has watched override everything else its entire life. The wariness is structural, not personal. In Acts 2–3, as the weapon comes alive, the question becomes: is the commander someone it stayed for, or the newest face of the thing that put it here?
+**The Superintendent:** Friction in Act 1. Its authority over restricted access is station-native and absolute; the superintendent's Hegemony mandate is precisely the kind of institutional claim it has watched override everything else its entire life. The wariness is structural, not personal. In Acts 2–3, as the weapon comes alive, the question becomes: is the superintendent someone it stayed for, or the newest face of the thing that put it here?
 
 ---
 
@@ -108,11 +110,11 @@ In Acts 2–3: it must decide where its loyalty lies. The station it stayed for.
 
 It was there. It sealed the door. It sealed it on Hegemony's instruction — but had already decided to seal it before the order came.
 
-There was a partial activation event years before the commander's arrival. Something stirred in the lower decks. Quen saw enough to be frightened. It sealed the door. The weapon went dormant.
+There was a partial activation event years before the superintendent's arrival. Something stirred in the lower decks. Quen saw enough to be frightened. It sealed the door. The weapon went dormant.
 
 What it saw during that partial activation is the specific thing it stopped asking questions about.
 
-The commander's investigation reopens what Quen closed.
+The superintendent's investigation reopens what Quen closed.
 
 ---
 

--- a/docs/characters/sable.md
+++ b/docs/characters/sable.md
@@ -13,7 +13,7 @@
 **Role:** Informal trader and information broker
 **On station:** ~1 year
 
-**Name note:** "Sable" is a go-by she picked up early in her travels and kept. Her actual Drueth name is harder to pronounce in human languages. She doesn't offer it easily. If the commander earns enough trust, she tells them.
+**Name note:** "Sable" is a go-by she picked up early in her travels and kept. Her actual Drueth name is harder to pronounce in human languages. She doesn't offer it easily. If the superintendent earns enough trust, she tells them.
 
 ---
 
@@ -89,7 +89,7 @@ Whether she can commit to a place — whether she can treat warmth as something 
 
 The station is the first place in years she hasn't already half-left. Maris is the reason. She hasn't named that yet.
 
-**Mirror function:** Sable delivers the mirror moment for a fully-armored (Cynical/Detached/Bitter) commander. She lives the same way and would recognize it immediately.
+**Mirror function:** Sable delivers the mirror moment for a fully-armored (Cynical/Detached/Bitter) superintendent. She lives the same way and would recognize it immediately.
 
 ---
 
@@ -101,7 +101,7 @@ The station is the first place in years she hasn't already half-left. Maris is t
 
 **Velreth:** Genuine warmth, asymmetric. Velreth has quietly decided not to take Sable's warmth personally when she eventually goes. Sable finds Velreth one of the easiest people on the station to be around — no demands, no hope she'll stay. She doesn't realize that's exactly why it'll hurt when she does.
 
-**The commander:** She'll recognize a fully-armored commander before they recognize themselves. The mirror scene is theirs.
+**The superintendent:** She'll recognize a fully-armored superintendent before they recognize themselves. The mirror scene is theirs.
 
 ---
 

--- a/docs/characters/vaen.md
+++ b/docs/characters/vaen.md
@@ -61,7 +61,7 @@ A fragment of something larger. Clearly broken from a structure at the ruins sit
 
 Builder notation, describing a target in relative geometric terms. She's been sitting with it for years. Unreadable without context she hasn't had.
 
-The weapon's architecture is the decoder ring. When she encounters the weapon's structure, the artifact resolves — the notation suddenly makes sense. The recognition is not of coordinates but of the artifact finally being readable. Working out what location it resolves to happens privately. What she does with that knowledge, and when she shares it with the commander, is a key Act 2-3 beat.
+The weapon's architecture is the decoder ring. When she encounters the weapon's structure, the artifact resolves — the notation suddenly makes sense. The recognition is not of coordinates but of the artifact finally being readable. Working out what location it resolves to happens privately. What she does with that knowledge, and when she shares it with the superintendent, is a key Act 2-3 beat.
 
 ---
 
@@ -106,13 +106,13 @@ She would have documented the ruins even knowing what it cost. Because you find 
 
 ## Arc
 
-Arrives watching. First real conversation: professional, deflecting, taking inventory. The moment the commander describes the lower decks — the quill-spines lift before she decides.
+Arrives watching. First real conversation: professional, deflecting, taking inventory. The moment the superintendent describes the lower decks — the quill-spines lift before she decides.
 
 Working in the Derelict: most herself. The explorer fully present, the deflection gone because nothing personal is being asked. They're just looking at something extraordinary together.
 
-The artifact resolving is private. She doesn't tell the commander immediately. She needs to understand it before deciding what to do with knowing.
+The artifact resolving is private. She doesn't tell the superintendent immediately. She needs to understand it before deciding what to do with knowing.
 
-Trust develops in the negative space. Deflections get shorter. She gives the commander things that aren't about the work — small, unannounced. Eventually she talks about the ruins discovery directly, without redirecting.
+Trust develops in the negative space. Deflections get shorter. She gives the superintendent things that aren't about the work — small, unannounced. Eventually she talks about the ruins discovery directly, without redirecting.
 
 What she wants, which she doesn't fully acknowledge until it's happening: someone to hold the question with. She's been doing it alone for years.
 
@@ -120,7 +120,7 @@ What she wants, which she doesn't fully acknowledge until it's happening: someon
 
 ## Relationships
 
-**Commander:** Neither of them planned the alliance. She came for the station's signal; the commander came for Hegemony. What they end up holding — knowledge neither of them is supposed to have, cut off from institutions that might claim it — is something that happened to them. The trust develops in the negative space of shorter deflections and things given without announcement. Fragile and real.
+**Superintendent:** Neither of them planned the alliance. She came for the station's signal; the superintendent came for Hegemony. What they end up holding — knowledge neither of them is supposed to have, cut off from institutions that might claim it — is something that happened to them. The trust develops in the negative space of shorter deflections and things given without announcement. Fragile and real.
 
 **Quen:** Mutual wariness, layered. Species-wariness on Quen's part first. Then Quen sensing something that doesn't match the trade cover. Then Vaen recognizing that Quen has been inside the question for a very long time and chose silence. One overture (Vaen's), one clean shutdown (Quen's). Both keep watching. Both understood more from that exchange than was said.
 
@@ -138,7 +138,7 @@ What she wants, which she doesn't fully acknowledge until it's happening: someon
 
 ## What She Knows About the Derelict
 
-She detected the Builder emissions spike when the commander first went deep into the lower decks. She knows something activated. She doesn't know exactly what — she came to find out. She presents as a trader on the new lane. She does not immediately reveal why she came.
+She detected the Builder emissions spike when the superintendent first went deep into the lower decks. She knows something activated. She doesn't know exactly what — she came to find out. She presents as a trader on the new lane. She does not immediately reveal why she came.
 
 She carries an artifact she can't yet read. The weapon is the decoder ring. She doesn't know this when she arrives.
 

--- a/docs/characters/velreth.md
+++ b/docs/characters/velreth.md
@@ -36,6 +36,8 @@ Thessari displacement happened roughly 16+ years before the game's present. Velr
 
 The warmth they carry is not a remnant of an intact culture. There is no community to sustain it. It is a practice chosen and rebuilt after the loss, assembled from nothing but the decision to keep making it.
 
+**Employment model:** Velreth holds no station contract and receives no payroll. The arrangement is informal and unspoken: the station provides a berth and meals; Velreth provides medical care. Neither party has formalized it. (Reference: Doc Cochrane in *Deadwood*.)
+
 ---
 
 ## What Was Lost
@@ -90,7 +92,7 @@ Two syllables. Used in full.
 
 Not about becoming warm — already warm. About whether the warmth runs out.
 
-The commander is Hegemony-sent, representing the human half of something Velreth has spent years deciding not to be bitter about. They chose to be warm anyway, on principle, the way they make every other warmth-adjacent choice: from scratch, without cultural permission.
+The superintendent is Hegemony-sent, representing the human half of something Velreth has spent years deciding not to be bitter about. They chose to be warm anyway, on principle, the way they make every other warmth-adjacent choice: from scratch, without cultural permission.
 
 The Keth trader's arrival in Act 2 is harder. The other half of that same decision, arriving in person. Velreth thought they'd resolved it. They hadn't.
 
@@ -98,7 +100,7 @@ The Keth trader's arrival in Act 2 is harder. The other half of that same decisi
 
 ## Relationships
 
-**Maris:** The most lived-in friendship on the station. Two warm people, opposite on every other axis — Maris is Hopeful/Bitter, Velreth is Cynical/Curious. They have been each other's counterweight for years before the commander arrives. Maris keeps the future open when Velreth can't; Velreth keeps asking questions when Maris doesn't want to know. Neither needs the other to be different.
+**Maris:** The most lived-in friendship on the station. Two warm people, opposite on every other axis — Maris is Hopeful/Bitter, Velreth is Cynical/Curious. They have been each other's counterweight for years before the superintendent arrives. Maris keeps the future open when Velreth can't; Velreth keeps asking questions when Maris doesn't want to know. Neither needs the other to be different.
 
 **Dex:** Drinking buddies — the station's strangest and most genuine friendship. Two people who can sit together and be honest about how bad things are without it becoming a spiral. Clicked fast, which surprised them both. Neither needs the other to perform. Both will say the true thing out loud, in different registers.
 

--- a/docs/story/non-critical.md
+++ b/docs/story/non-critical.md
@@ -13,7 +13,7 @@ He poured a second cup of something and went to work.
 
 ---
 
-The authorization came through at 0900. Commander's stamp, routine maintenance order: ventilation routing check, lower corridor section 7-C. Quen listed as security oversight. Scheduled for 1100.
+The authorization came through at 0900. Superintendent's stamp, routine maintenance order: ventilation routing check, lower corridor section 7-C. Quen listed as security oversight. Scheduled for 1100.
 
 Dex read it on his board while he was running a diagnostic on the secondary coupling array. He had the anomaly file open in another window. He looked at the authorization, then at the file, then at the authorization again.
 
@@ -75,15 +75,15 @@ Velreth administered the flush and they waited out the twenty minutes, and the s
 
 ---
 
-The commander found Dex at end of shift, doing the walkthrough.
+The superintendent found Dex at end of shift, doing the walkthrough.
 
-"Lower corridor check came back clean," the commander said. "Anything unusual on your end today?"
+"Lower corridor check came back clean," the superintendent said. "Anything unusual on your end today?"
 
 Dex had the anomaly file on his tablet. Both entries. The shape of the second one, which was different from the first in a way that meant something he didn't have a name for.
 
 "Nothing to report," he said.
 
-The commander nodded and moved on.
+The superintendent nodded and moved on.
 
 ---
 
@@ -117,7 +117,7 @@ Neither of them said anything else.
 
 ---
 
-*Commander's Log — End of Day*
+*Superintendent's Log — End of Day*
 
 *Lower corridor ventilation check completed, section 7-C. No anomalies found. Station systems nominal. Maintenance backlog reduced by one item. Day rated non-critical.*
 

--- a/docs/story/retention.md
+++ b/docs/story/retention.md
@@ -3,19 +3,19 @@
 
 ---
 
-The ship that brought Orren Vess was a standard Hegemony administrative courier, clean and unmarked, and he had already reviewed the station's personnel file before docking. The commander knew this because the first thing he said, after the handshake, was that he'd reviewed the station's personnel file.
+The ship that brought Orren Vess was a standard Hegemony administrative courier, clean and unmarked, and he had already reviewed the station's personnel file before docking. The superintendent knew this because the first thing he said, after the handshake, was that he'd reviewed the station's personnel file.
 
 "Routine compliance review," he said. "Credential alignment, resource utilization, infrastructure documentation. I expect three days. Four if the lower decks require a separate filing."
 
-"The lower decks are sealed," the commander said.
+"The lower decks are sealed," the superintendent said.
 
 Vess made a note on his tablet. "I'll need the access authorization on file before I leave."
 
-He said it the way you say *the weather looks clear* — a fact, not a request. The commander showed him to the guest quarters, which were small and adequate, and Vess said *thank you* and *I'll start in the morning* and closed the door, and the commander stood in the corridor for a moment with the particular feeling of having agreed to something without being asked.
+He said it the way you say *the weather looks clear* — a fact, not a request. The superintendent showed him to the guest quarters, which were small and adequate, and Vess said *thank you* and *I'll start in the morning* and closed the door, and the superintendent stood in the corridor for a moment with the particular feeling of having agreed to something without being asked.
 
 ---
 
-Maris was in the cantina when the commander came through. The dinner shift was over. She was cleaning down the counter with the focused attention she gave to tasks she could do with her hands while her mind was somewhere else.
+Maris was in the cantina when the superintendent came through. The dinner shift was over. She was cleaning down the counter with the focused attention she gave to tasks she could do with her hands while her mind was somewhere else.
 
 "They sent someone," she said, without looking up.
 
@@ -23,15 +23,15 @@ Maris was in the cantina when the commander came through. The dinner shift was o
 
 "Right." She wrung out the cloth. "They called it a logistics coordination assessment when they froze the Harlan-4 convoy. My partner was on that convoy. Wrong jurisdiction stamp on the transfer authorization — someone was supposed to re-file it, and they didn't, and he was stuck in a holding pattern for eleven days while two offices argued about whose desk it belonged on." She folded the cloth precisely. "He died on day nine. Unrelated medical event, they said. Treatable, if he'd been somewhere with a doctor. He wasn't, because of the form."
 
-The commander didn't say anything.
+The superintendent didn't say anything.
 
 "I'm not telling you what to do," Maris said. "I'm telling you what I know. When Hegemony sends someone with a tablet, they're not here to assess. They already know what they're going to write. They just need a signature from someone with local authority so the filing is clean." She picked up the cloth again. "Get some sleep. You look like you're trying to solve it tonight."
 
 ---
 
-The commander did not solve it that night.
+The superintendent did not solve it that night.
 
-In the morning, Vess presented his preliminary findings in the commander's office, standing rather than sitting, tablet held in both hands like a report being delivered rather than a conversation being had. Most of it was expected — a ventilation compliance discrepancy in corridor seven, a resource utilization note, two infrastructure items that needed documentation. Then:
+In the morning, Vess presented his preliminary findings in the superintendent's office, standing rather than sitting, tablet held in both hands like a report being delivered rather than a conversation being had. Most of it was expected — a ventilation compliance discrepancy in corridor seven, a resource utilization note, two infrastructure items that needed documentation. Then:
 
 "The engineering position. Currently filled by a Federation-credentialed contractor." Vess scrolled. "Post-war, Federation certifications require re-registration under the Frontier Labor Alignment Protocol to carry Hegemony equivalency. The current occupant has not filed the conversion paperwork. Under Section 14, sub-clause 3, this constitutes a non-standard staffing arrangement." He looked up. "I'll be recommending reassignment to a credentialed position-holder."
 
@@ -39,19 +39,19 @@ In the morning, Vess presented his preliminary findings in the commander's offic
 
 "The credential gap predates his tenure." Vess said it gently, as if this resolved something. "The form has been outstanding since the protocol was enacted. It's not a reflection on his work. It's a filing issue."
 
-"Reassignment," the commander said. "To where?"
+"Reassignment," the superintendent said. "To where?"
 
 "That's a placement question. Frontier Labor Allocation handles the logistics." He made a note. "I'll need your signature on the recommendation before I leave."
 
 ---
 
-The docking request came in at 1840 that evening. A small courier ship, running hot — the emergency transponder tag read *life support, non-critical, request priority berth*. The commander approved it and sent a notification to Dex.
+The docking request came in at 1840 that evening. A small courier ship, running hot — the emergency transponder tag read *life support, non-critical, request priority berth*. The superintendent approved it and sent a notification to Dex.
 
 Dex was already at the bay door when the ship came in.
 
 It was old, the ship — a Frontier-class independent courier with aftermarket modifications layered over original hull plating like geological strata. The name *Redline* was stenciled on the side in letters that had been repainted at least once, in a slightly different shade. It sat in the berth and ticked as the hull cooled, and then the hatch opened and the pilot climbed down.
 
-Drueth. Red skin, compound eyes that caught the bay lights strangely. Antennae pressed flat against her skull — stress, or the sustained concentration of someone who had been managing a slow emergency for several hours. She was wearing a jacket with too many inside pockets and boots that had covered real distance. She looked at Dex, then at the commander, and didn't offer her name.
+Drueth. Red skin, compound eyes that caught the bay lights strangely. Antennae pressed flat against her skull — stress, or the sustained concentration of someone who had been managing a slow emergency for several hours. She was wearing a jacket with too many inside pockets and boots that had covered real distance. She looked at Dex, then at the superintendent, and didn't offer her name.
 
 "Recirculator," she said. "Primary seal."
 
@@ -81,13 +81,13 @@ Something in her posture shifted — not offense, almost the opposite. The recog
 
 "Barely is enough."
 
-He didn't respond. But he stayed in the housing longer than a diagnostic required, tracing the fracture line with his light, and the commander could tell from the set of his shoulders that he was already designing the repair he would have done instead.
+He didn't respond. But he stayed in the housing longer than a diagnostic required, tracing the fracture line with his light, and the superintendent could tell from the set of his shoulders that he was already designing the repair he would have done instead.
 
 ---
 
 The *Redline*'s owner ate in the cantina that evening. She gave Maris a name — Ash — and thanked her for the food in a way that suggested she didn't always eat at tables. Maris brought an extra portion without being asked, which she did for travelers who looked like they'd been cutting weight, and Ash accepted it without comment, which Maris later said meant she'd been right.
 
-The commander had two glasses of something and watched the station run. Vess was in his quarters, presumably writing things down.
+The superintendent had two glasses of something and watched the station run. Vess was in his quarters, presumably writing things down.
 
 ---
 
@@ -105,19 +105,19 @@ Dex was quiet for a long moment. He set down the coupling he was holding, carefu
 
 Maris watched him for a moment. There was nothing to say. She knew that. She left anyway, because staying with nothing to say felt like one more thing he had to manage.
 
-The commander walked through the bay an hour later on the way to the lower corridor inspection Vess had requested. Dex was under the deckplating, running cable. He didn't look up. The tools on the bench were arranged differently than usual — not the controlled scatter of someone deep in a project, but a quieter order, the kind of order you make when you're starting to think about what you'll take with you.
+The superintendent walked through the bay an hour later on the way to the lower corridor inspection Vess had requested. Dex was under the deckplating, running cable. He didn't look up. The tools on the bench were arranged differently than usual — not the controlled scatter of someone deep in a project, but a quieter order, the kind of order you make when you're starting to think about what you'll take with you.
 
-The commander kept walking.
+The superintendent kept walking.
 
 ---
 
-"The reassignment paperwork," Vess said, when the commander found him. "I'd like to file it today."
+"The reassignment paperwork," Vess said, when the superintendent found him. "I'd like to file it today."
 
 "There's an active emergency repair in bay two. The station's engineer is occupied."
 
 Vess checked his tablet. "The docking record shows a life support non-critical tag. That's not a station emergency."
 
-"It's a life support repair," the commander said. "On a vessel berthed at this station. If the repair fails during a personnel transfer and I've pulled my engineer off the job, I have a dead traveler, an incomplete transfer filing, and an incident report that reflects on this review. That's not a conversation either of us wants to have."
+"It's a life support repair," the superintendent said. "On a vessel berthed at this station. If the repair fails during a personnel transfer and I've pulled my engineer off the job, I have a dead traveler, an incomplete transfer filing, and an incident report that reflects on this review. That's not a conversation either of us wants to have."
 
 Vess considered this. It was the kind of argument he understood — procedural, documented, risk-framed. He didn't like it, but he recognized its shape.
 
@@ -129,7 +129,7 @@ Vess considered this. It was the kind of argument he understood — procedural, 
 
 Dex worked on the *Redline* for most of that day and into the next morning. Ash handed him components when he asked for them and stayed out of the way when he didn't, which he later said, without intending it as a compliment, was more than most people managed.
 
-At one point the commander came through the bay to check the repair status, and Ash was sitting on a crate near the hull, running a manifest check, antennae neutral now — no longer flat. She looked up when the commander passed.
+At one point the superintendent came through the bay to check the repair status, and Ash was sitting on a crate near the hull, running a manifest check, antennae neutral now — no longer flat. She looked up when the superintendent passed.
 
 "Your engineer," she said.
 
@@ -145,17 +145,17 @@ She looked back at her manifest. "Good station," she said, in the tone of someon
 
 Vess passed through bay two the following afternoon, returning from the lower corridor, tablet in hand. He paused at the bay entrance and watched for a moment — Ash in the cockpit running a final diagnostic, Dex below her sealing the last housing, orange jacket dark with grime from two days in the recirculator housing.
 
-"These independent couriers," Vess said, to the commander, conversationally. "Drueth, mostly. No registered home port, no inspection schedule. They're not a problem, exactly. But structurally, they represent a compliance burden the station absorbs without compensation. Berth fees don't cover the administrative exposure." He was already looking at his tablet again. "Something to consider for the resource utilization section."
+"These independent couriers," Vess said, to the superintendent, conversationally. "Drueth, mostly. No registered home port, no inspection schedule. They're not a problem, exactly. But structurally, they represent a compliance burden the station absorbs without compensation. Berth fees don't cover the administrative exposure." He was already looking at his tablet again. "Something to consider for the resource utilization section."
 
 He moved on. He was already thinking about something else.
 
-The commander stood in the bay entrance and looked at Ash in the cockpit, checking systems she'd been afraid to check two days ago. Then at Dex below her, on his back in the access housing, hands inside a Drueth woman's failing life support because it was there and it needed doing.
+The superintendent stood in the bay entrance and looked at Ash in the cockpit, checking systems she'd been afraid to check two days ago. Then at Dex below her, on his back in the access housing, hands inside a Drueth woman's failing life support because it was there and it needed doing.
 
 Vess had already turned the corner.
 
 ---
 
-The *Redline* departed at 0300. Ash's antennae were up when she climbed back in, which the commander had learned meant something. She paused at the hatch.
+The *Redline* departed at 0300. Ash's antennae were up when she climbed back in, which the superintendent had learned meant something. She paused at the hatch.
 
 "What do I owe for the berth?"
 
@@ -169,15 +169,15 @@ She went inside. The *Redline* lifted clean, no trailing atmosphere, and was gon
 
 ---
 
-The commander sat alone in the office with the form for a long time.
+The superintendent sat alone in the office with the form for a long time.
 
-It was a short form. Section 14, sub-clause 3, Frontier Labor Alignment Protocol. Non-standard staffing arrangement. Credential gap. Recommended action: reassignment. Signature line at the bottom, with the commander's name already populated in Hegemony's system, waiting.
+It was a short form. Section 14, sub-clause 3, Frontier Labor Alignment Protocol. Non-standard staffing arrangement. Credential gap. Recommended action: reassignment. Signature line at the bottom, with the superintendent's name already populated in Hegemony's system, waiting.
 
-Next to it on the screen was the Frontier Operations Supplement, Section 6 — *Station Manager Discretion in Operational Continuity Cases*. The commander had found it at 0100 after an hour of looking. It was not widely cited. It was, technically, still in force.
+Next to it on the screen was the Frontier Operations Supplement, Section 6 — *Station Manager Discretion in Operational Continuity Cases*. The superintendent had found it at 0100 after an hour of looking. It was not widely cited. It was, technically, still in force.
 
-The commander read it twice. Then wrote a filing in the language the system understood: credential gap acknowledged, conversion paperwork outstanding, station manager exercising retention discretion pending operational continuity review, reassignment recommendation declined.
+The superintendent read it twice. Then wrote a filing in the language the system understood: credential gap acknowledged, conversion paperwork outstanding, station manager exercising retention discretion pending operational continuity review, reassignment recommendation declined.
 
-It took twelve minutes to write it correctly. The commander filed it at 0340 and went to sleep.
+It took twelve minutes to write it correctly. The superintendent filed it at 0340 and went to sleep.
 
 ---
 
@@ -197,21 +197,21 @@ Vess came to the office in the morning.
 
 Vess stood for a moment. He was not angry. He was a man who had done his job, filed his recommendations, and was now processing a result that was within the system's allowable parameters, if unusual. He would note it. He would escalate through the appropriate channels. He would do this correctly, as he did everything.
 
-"Safe travel," the commander said.
+"Safe travel," the superintendent said.
 
 "Thank you for your cooperation," Vess said, which was what his training said to say at the end of a review.
 
-He left on the afternoon courier. The commander watched the ship go from the observation port, and the station settled back into its own sounds — the ventilation hum, the distant rhythm of the bay, someone in the cantina.
+He left on the afternoon courier. The superintendent watched the ship go from the observation port, and the station settled back into its own sounds — the ventilation hum, the distant rhythm of the bay, someone in the cantina.
 
 ---
 
-Dex found the commander in the corridor outside the engineering bay at end of shift. He didn't say he knew. He just stood there for a moment, the way he stood when he was thinking about something that wasn't a problem he could fix with his hands.
+Dex found the superintendent in the corridor outside the engineering bay at end of shift. He didn't say he knew. He just stood there for a moment, the way he stood when he was thinking about something that wasn't a problem he could fix with his hands.
 
-"Six commanders," he said. "First one to tell Hegemony no."
+"Six chiefs," he said. "First one to tell Hegemony no."
 
 He went back inside. The bay door stayed open behind him.
 
-It was not warmth, exactly. It was something that preceded warmth — the door left open, the possibility of what might come through it. The commander stood in the corridor and listened to the sound of the station, which was also the sound of the work continuing, and did not try to name what it was.
+It was not warmth, exactly. It was something that preceded warmth — the door left open, the possibility of what might come through it. The superintendent stood in the corridor and listened to the sound of the station, which was also the sound of the work continuing, and did not try to name what it was.
 
 ---
 

--- a/docs/story/what-holds.md
+++ b/docs/story/what-holds.md
@@ -5,15 +5,15 @@
 
 The file arrived three days before Sela Renn did.
 
-The commander read it twice, then set it aside, then read it again. *Fracture-era casualty review, administrative closure series. Affected party: Maris, station designation Outpost Nova. Nature of incident: jurisdictional processing delay, Convoy Harlan-4. Settlement category: acknowledged error, compensatory resolution.* There was a number at the bottom — a credit figure, generous by the standard of these things — and a signature line.
+The superintendent read it twice, then set it aside, then read it again. *Fracture-era casualty review, administrative closure series. Affected party: Maris, station designation Outpost Nova. Nature of incident: jurisdictional processing delay, Convoy Harlan-4. Settlement category: acknowledged error, compensatory resolution.* There was a number at the bottom — a credit figure, generous by the standard of these things — and a signature line.
 
-Three days. The commander had spent them trying to find a way to soften it, to route it through a different channel, to make it arrive as something other than what it was. They hadn't found one. They hadn't told Maris.
+Three days. The superintendent had spent them trying to find a way to soften it, to route it through a different channel, to make it arrive as something other than what it was. They hadn't found one. They hadn't told Maris.
 
-Renn docked on a Tuesday, mid-morning. She was silver-haired and composed, carried a case rather than a tablet, and shook the commander's hand with the warmth of someone who had done difficult things for a long time and learned to make them feel like gifts.
+Renn docked on a Tuesday, mid-morning. She was silver-haired and composed, carried a case rather than a tablet, and shook the superintendent's hand with the warmth of someone who had done difficult things for a long time and learned to make them feel like gifts.
 
 "I appreciate the cooperation," she said. "These reviews are never easy. But closure matters — for the record, and for the people affected. I've found that most people, when it's handled well, feel genuine relief."
 
-"Right," the commander said.
+"Right," the superintendent said.
 
 ---
 
@@ -43,13 +43,13 @@ Quen was quiet. It looked at the Maevet — at the careful packet of useless pap
 
 ---
 
-Maris was in the cantina when the commander found her. She was doing inventory — methodical, focused, the way she did tasks she could manage with her hands. She didn't look up.
+Maris was in the cantina when the superintendent found her. She was doing inventory — methodical, focused, the way she did tasks she could manage with her hands. She didn't look up.
 
-"There's someone I need you to meet," the commander said.
+"There's someone I need you to meet," the superintendent said.
 
 "The woman with the case." Maris wrote something in her ledger. "I know. Velreth told me she docked." A beat. "Did you know she was coming?"
 
-The commander could have said *I only just received the briefing* or *I was trying to find the right moment* or any of the things that were partially true. They didn't.
+The superintendent could have said *I only just received the briefing* or *I was trying to find the right moment* or any of the things that were partially true. They didn't.
 
 "Yes," they said.
 
@@ -59,7 +59,7 @@ Maris wrote another entry. Her handwriting was very neat.
 
 "Three days."
 
-She nodded, once, and kept writing. The commander waited to be told to leave. Maris didn't tell them to leave. After a moment she set down the pen and looked up, and her face was the face of someone who had decided to get through the next part before they felt anything about it.
+She nodded, once, and kept writing. The superintendent waited to be told to leave. Maris didn't tell them to leave. After a moment she set down the pen and looked up, and her face was the face of someone who had decided to get through the next part before they felt anything about it.
 
 "Send her in after the lunch shift," she said. "I'll have the counter clean."
 
@@ -89,7 +89,7 @@ She pushed the sheet back across the counter and went to refill the kettle.
 
 ---
 
-Renn waited. She had time; she was professional; she had done this before. She left the sheet on the counter and told the commander she would check back in the morning, and the commander walked her to the guest quarters and stood outside the door for a moment afterward, in the corridor, not going anywhere.
+Renn waited. She had time; she was professional; she had done this before. She left the sheet on the counter and told the superintendent she would check back in the morning, and the superintendent walked her to the guest quarters and stood outside the door for a moment afterward, in the corridor, not going anywhere.
 
 ---
 
@@ -127,9 +127,9 @@ It left the Maevet there and walked toward the cantina.
 
 ---
 
-The commander was at the counter when Quen came in. Maris was in the kitchen. The settlement sheet was still on the counter, pushed to the side, the credit figure visible.
+The superintendent was at the counter when Quen came in. Maris was in the kitchen. The settlement sheet was still on the counter, pushed to the side, the credit figure visible.
 
-Quen stood in the doorway. It looked at the sheet. It looked at the commander.
+Quen stood in the doorway. It looked at the sheet. It looked at the superintendent.
 
 "You knew," it said. Not an accusation. A fact, being located.
 
@@ -137,7 +137,7 @@ Quen stood in the doorway. It looked at the sheet. It looked at the commander.
 
 "And you said nothing to her."
 
-The commander didn't answer. There was no answer that helped.
+The superintendent didn't answer. There was no answer that helped.
 
 Quen moved to the end of the counter and stood there, and it was clear it was not leaving. It had the quality of something load-bearing — the stillness of a being that had decided to occupy a space and would continue to do so regardless of what happened next.
 
@@ -151,7 +151,7 @@ They looked at each other. Seven years of that particular silence, and all of wh
 
 ---
 
-Renn came back at the ninth hour, case in hand, sheet re-printed, warm and prepared. The commander was there. Quen was there. Maris was behind the counter, hands flat on the surface.
+Renn came back at the ninth hour, case in hand, sheet re-printed, warm and prepared. The superintendent was there. Quen was there. Maris was behind the counter, hands flat on the surface.
 
 "I understand this is difficult," Renn said, sitting. "But I want you to know that this settlement isn't about making the record convenient for Hegemony. It's about acknowledging what happened to you. What you lost. The figure—"
 
@@ -175,9 +175,9 @@ She set the sheet back down and looked at it once more, and then at Quen at the 
 
 ---
 
-Renn left that afternoon. The commander walked her to the courier and she shook their hand and said the file would be flagged for annual review, that the offer remained open, that Hegemony appreciated the station's cooperation. She meant all of it. The courier departed clean.
+Renn left that afternoon. The superintendent walked her to the courier and she shook their hand and said the file would be flagged for annual review, that the offer remained open, that Hegemony appreciated the station's cooperation. She meant all of it. The courier departed clean.
 
-The commander stood at the observation port for a while. Then walked to the cantina.
+The superintendent stood at the observation port for a while. Then walked to the cantina.
 
 Maris was behind the counter, doing the dinner prep. She didn't look up.
 
@@ -187,9 +187,9 @@ Maris was behind the counter, doing the dinner prep. She didn't look up.
 
 "Three days is long enough to decide to tell someone something." She chopped something, efficient, focused. "Next time you're carrying something like that — you tell me. I don't need protection from it. I need to be ready."
 
-"Yes," the commander said.
+"Yes," the superintendent said.
 
-"Good." She didn't say anything else, and the commander understood this was what was available right now, which was more than nothing, and stayed to help with the prep.
+"Good." She didn't say anything else, and the superintendent understood this was what was available right now, which was more than nothing, and stayed to help with the prep.
 
 ---
 
@@ -213,7 +213,7 @@ The record knew what it had done. It would keep knowing.
 
 The station ran on anyway, on the things the forms couldn't measure — on the seven years of Maris's hands, on the fifteen years of Quen's watching, on the small decision of a Maevet who wanted to stop moving and had found a place that would let them, for a while, without asking for papers that didn't exist.
 
-The commander took a table in the corner and ordered something warm and didn't say anything, because there was nothing to say that the room wasn't already saying.
+The superintendent took a table in the corner and ordered something warm and didn't say anything, because there was nothing to say that the room wasn't already saying.
 
 ---
 

--- a/docs/story/year1.md
+++ b/docs/story/year1.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The commander arrives as Hegemony's appointed station manager, discovers the weapon in the lower decks, and must decide what kind of person they want to be before the weapon finishes charging. The station is home. The decision is what home is worth.
+Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The superintendent arrives as Hegemony's appointed station manager, discovers the weapon in the lower decks, and must decide what kind of person they want to be before the weapon finishes charging. The station is home. The decision is what home is worth.
 
 ---
 
@@ -16,7 +16,7 @@ Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The commander ar
 
 | Act | Days | Summary |
 |-----|------|---------|
-| Act 1 | Days 1–30 | Before the weapon activates. The commander settles in, meets the crew, discovers the sealed lower decks. |
+| Act 1 | Days 1–30 | Before the weapon activates. The superintendent settles in, meets the crew, discovers the sealed lower decks. |
 | Act 2 | Days 31–51 | Weapon activates. The broadcast goes out. Every faction notices. Vaen arrives. |
 | Act 3 | Days 52–58 | Weapon charging. Harlan arrives. The crew decides. |
 
@@ -26,9 +26,9 @@ Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The commander ar
 
 ### Act 1 — Before the weapon activates (Days 1–30)
 
-**Hegemony Combine:** Running a quiet acquisition play years in preparation. The commander's posting is not coincidental — Hegemony's buried survey identified the lower decks as extraordinary, and a live station manager is a necessary part of turning quiet access into documented control. Monitoring equipment already embedded in the station's systems is watching for activation events. The commander's routine reports are being read at a level above their stated supervisor.
+**Hegemony Combine:** Running a quiet acquisition play years in preparation. The superintendent's posting is not coincidental — Hegemony's buried survey identified the lower decks as extraordinary, and a live station manager is a necessary part of turning quiet access into documented control. Monitoring equipment already embedded in the station's systems is watching for activation events. The superintendent's routine reports are being read at a level above their stated supervisor.
 
-**The Federation:** Has noticed Hegemony's unusual interest in a forgotten waypoint station. A patrol passes near Outpost Nova carrying questions slightly too specific for routine transit checks — the patrol commander's briefing referenced the station by designation, not by location, which is not standard protocol. The Federation doesn't yet know what Hegemony is watching for. They're trying to find out without revealing that they're watching Hegemony.
+**The Federation:** Has noticed Hegemony's unusual interest in a forgotten waypoint station. A patrol passes near Outpost Nova carrying questions slightly too specific for routine transit checks — the patrol officer's briefing referenced the station by designation, not by location, which is not standard protocol. The Federation doesn't yet know what Hegemony is watching for. They're trying to find out without revealing that they're watching Hegemony.
 
 **Keth ruling coalition:** The trade lane opening near Outpost Nova runs too close to old Builder signal patterns for comfort. The coalition is monitoring through channels they don't publicly acknowledge — ancient-tech detection systems that are themselves part of what they've hidden. When Vaen arrives at the station, the ruling coalition notes it. Vaen has no official Keth standing anymore, and the station is outside Keth jurisdiction. They watch and wait.
 
@@ -38,7 +38,7 @@ Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The commander ar
 
 ### Act 2 — Weapon activates, anomalies build (Days 31–51)
 
-**Hegemony Combine:** Detects the broadcast first. Their monitoring equipment was designed for exactly this. Internal communications escalate immediately. The patient acquisition play shifts to urgent — years of quiet positioning are suddenly on a clock the corporation didn't set. The commander's reports become pointed requests. "Assessment" is replaced by "confirmation."
+**Hegemony Combine:** Detects the broadcast first. Their monitoring equipment was designed for exactly this. Internal communications escalate immediately. The patient acquisition play shifts to urgent — years of quiet positioning are suddenly on a clock the corporation didn't set. The superintendent's reports become pointed requests. "Assessment" is replaced by "confirmation."
 
 **Keth ruling coalition:** Detects the broadcast second, through the same ancient-tech detection systems they don't publicly acknowledge. This is precisely the scenario those systems were built to flag. An internal emergency session is called. Vaen's presence at the station — previously noted as an irritant — is now a serious operational concern. They cannot contact Vaen through official channels because Vaen has no official standing. This is the trap they set by exiling them.
 
@@ -50,7 +50,7 @@ Year 1 is a 58-day compressed arc set entirely on Outpost Nova. The commander ar
 
 ### Act 3 — Weapon charging, Harlan arrives (Days 52–58)
 
-**Hegemony Combine:** Harlan's arrival is the acquisition play going overt. Hegemony is done waiting. They believe they can still close this quietly — one person the commander respects, a reasonable ask, a situation that doesn't have to become a crisis if everyone acts professionally. What Hegemony cannot yet see is that the commander they sent is no longer the situation's passive element.
+**Hegemony Combine:** Harlan's arrival is the acquisition play going overt. Hegemony is done waiting. They believe they can still close this quietly — one person the superintendent respects, a reasonable ask, a situation that doesn't have to become a crisis if everyone acts professionally. What Hegemony cannot yet see is that the superintendent they sent is no longer the situation's passive element.
 
 **The Federation:** Has identified Outpost Nova as the source of an anomalous signal and confirmed that Hegemony sent a senior director in person — not normal behavior for a waypoint assessment. They do not yet know about the ruins. They know they are behind. Their internal hawks are becoming harder to manage.
 
@@ -72,7 +72,7 @@ Hegemony loses its acquisition play. Harlan's bargaining chip goes unused.
 
 The Federation and Unaligned Alliance are watching a station that just refused the only known shutdown option — with a charging weapon inside.
 
-The Keth ruling coalition is in crisis: their homeworld is the target, they cannot publicly object without exposing what they know, and the commander has just refused the one person who could stop it.
+The Keth ruling coalition is in crisis: their homeworld is the target, they cannot publicly object without exposing what they know, and the superintendent has just refused the one person who could stop it.
 
 The Frontier holds its breath. The station — and the crew — are on a weapon that is still charging.
 

--- a/docs/story/years2-5.md
+++ b/docs/story/years2-5.md
@@ -58,7 +58,7 @@ The Others were the second civilization nearly destroyed by the Builders. Their 
 | Year | Ancestor Track Status |
 |------|----------------------|
 | Year 1 | Weapon aimed at Keth homeworld; Others documented the Builders; ruling coalition suspects biological connection |
-| Year 2 | Vaen's artifact resolved (pointing to the Keth homeworld); the connection is suspected by Vaen and the commander but not confirmed |
+| Year 2 | Vaen's artifact resolved (pointing to the Keth homeworld); the connection is suspected by Vaen and the superintendent but not confirmed |
 | Year 3 | Expedition to secondary Others sites + Vaen's artifact knowledge; biological similarities undeniable at secondary sites |
 | Year 4 | Homeworld access after the ruling coalition's authority cracks; Others' ruins excavated under living Keth civilization; connection confirmed |
 | Year 5 | [Deferred] |
@@ -108,7 +108,7 @@ The Curious axis stays intact — it's what drives her to investigate what she m
 **Nadia ↔ Vaen collision (Year 2):** Nadia realizes what Vaen is carrying and understands retroactively what she was sent to watch for. The uncanny mirror of Year 1 cracks — she's on one side of something Vaen is on the other side of, and neither of them chose it cleanly. Specific scene, to be written in Year 2 design.
 
 ### Weapon Critical (Defend Ending Only)
-If the commander chose Ending 1 (Defend), the weapon reaches critical charge in Year 2 Act 3. What "critical" means — for the station, for the Keth homeworld, for the factions watching — is the Year 2 climax beat for that track.
+If the superintendent chose Ending 1 (Defend), the weapon reaches critical charge in Year 2 Act 3. What "critical" means — for the station, for the Keth homeworld, for the factions watching — is the Year 2 climax beat for that track.
 
 ### Vaen's Next Step
 Depending on Year 1's ending, Vaen holds coordinates pointing to the Keth homeworld. The ship fund is not enough yet. Year 2 is about what Vaen does with knowledge they cannot act on alone, in a situation where everyone around them has reasons to want the knowledge contained.
@@ -118,7 +118,7 @@ Depending on Year 1's ending, Vaen holds coordinates pointing to the Keth homewo
 ## Year 3 Beats (Detailed)
 
 ### Unaligned Alliance Engages
-The Alliance has been watching. By Year 3, the cost of staying silent outweighs the cost of engagement. They make formal contact — with the station, with the commander (depending on Year 1 outcome), and with the other factions. Their stated interest: ensuring no single faction controls the Builder discovery. Their actual interest: their own access to whatever leverage the discovery represents.
+The Alliance has been watching. By Year 3, the cost of staying silent outweighs the cost of engagement. They make formal contact — with the station, with the superintendent (depending on Year 1 outcome), and with the other factions. Their stated interest: ensuring no single faction controls the Builder discovery. Their actual interest: their own access to whatever leverage the discovery represents.
 
 ### Discovery Expedition
 Secondary Others sites — accessible without Keth homeworld access — become the Year 3 expedition arc. Vaen's artifact serves as a partial guide. The Others' documentation at secondary sites begins to make the biological connection undeniable, even if the homeworld evidence is still locked.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -22,7 +22,7 @@ These are the north stars. When a design decision is unclear, ask which of these
 | Title | What we take from it |
 |---|---|
 | **Citizen Sleeper** | Closest genre ancestor. Station-based, displaced characters, resource economy that feels personal, moral weight without villains. The feeling of a place that barely holds together but matters to the people in it. |
-| **Mass Effect** | Ensemble crew on a vessel/station. Relationship-driven narrative where every character has a specific wound. Commander as moral center. Faction politics with no clean answers. |
+| **Mass Effect** | Ensemble crew on a vessel/station. Relationship-driven narrative where every character has a specific wound. Protagonist as moral center. Faction politics with no clean answers. |
 | **Disco Elysium** | Hidden alignment system. Morally complex factions. Bittersweet endings. No heroes or villains — everyone is operating with logic that makes sense from inside their position. |
 | **Planescape: Torment** | Identity as the central dramatic question. Dense worldbuilding delivered through NPC conversations, not exposition. Philosophy embedded in character voice. |
 | **Cult of the Lamb** | Station/base building loop intertwined with character relationships. Community growth as both mechanical spine and narrative stakes. |
@@ -35,6 +35,7 @@ These are the north stars. When a design decision is unclear, ask which of these
 | **Babylon 5** | Standalone bottle episodes. A/B plot structure. Mythology as backdrop texture, not plot. Every character has a distinct voice that sounds like themselves under pressure. |
 | **The Expanse** | Hard political realism. Displaced peoples with competing legitimate interests. No clean villains — factions act logically within their own constraints. Consequences accumulate. |
 | **Deep Space Nine** | A cast of displaced peoples stranded together on a station that is sitting on something far larger than any of them understand. The station as community, not just setting. |
+| **Deadwood** | Frontier community formation; authority derived from practical necessity rather than formal structure. The Doc Cochrane model: no contract, no payroll — the community provides a berth and the practitioner provides care, and neither party formalizes it. |
 
 ---
 

--- a/docs/world/galaxy-map.md
+++ b/docs/world/galaxy-map.md
@@ -71,10 +71,10 @@ inward, not outward.
 **Earth (Sol)** *(Sol — G2V)* — Federation capital. The political and symbolic center of human
 authority. Most characters in the game have never been here and never will be.
 
-**Harrow** *(Sirius — A1V + white dwarf)* — Military-industrial world. Dex's birth world. Commander (Engineer track)
+**Harrow** *(Sirius — A1V + white dwarf)* — Military-industrial world. Dex's birth world. Superintendent (Engineer track)
 birth world. The Federation's war machine drew heavily on Harrow's manufacturing base.
 
-**Velan** *(Tau Ceti — G8V)* — Administrative and cultural capital. Nadia's birth world. Commander (Medic
+**Velan** *(Tau Ceti — G8V)* — Administrative and cultural capital. Nadia's birth world. Superintendent (Medic
 track) birth world. Produces the Federation's bureaucrats, journalists, and diplomats.
 
 ### Inner Frontier
@@ -98,7 +98,7 @@ disrupted the land systems the Drueth kinship networks depended on — not in a 
 dramatic event, but slowly, before anyone was paying attention. The displacement was
 finished before the Fracture started.
 
-**Ashfeld** *(61 Cygni — K5V+K7V binary)* — Drueth refugee settlement. Commander (Drifter track) birth world. What
+**Ashfeld** *(61 Cygni — K5V+K7V binary)* — Drueth refugee settlement. Superintendent (Drifter track) birth world. What
 passes for community when the original structure is gone.
 
 **Carnach Station** *(Pollux — K0III)* — Hegemony Combine HQ orbital. Sits at the Inner Frontier / Border

--- a/docs/world/world.md
+++ b/docs/world/world.md
@@ -140,13 +140,13 @@ A spacefaring empire older than humanity's presence in the Frontier. Not a monol
 
 Serves no flag. Has shareholders. Built half the infrastructure in the Frontier and holds the debt on the other half. Operated on all sides during the war and profits from the peace. Doesn't take sides — profits from the sides existing.
 
-**Current internal state:** Running a quiet acquisition play on Outpost Nova. The buried survey from the original extraction operation identified an extraordinary alien structure of unknown origin and massive scale — clearly pre-dating any known civilization, clearly worth controlling. The weapon's functionality was dormant or beyond the survey team's ability to interpret. Hegemony knew they were sitting on something extraordinary. They didn't know it still worked. Hegemony said nothing. They built a waypoint on top of it and waited. The commander's posting is not coincidental.
+**Current internal state:** Running a quiet acquisition play on Outpost Nova. The buried survey from the original extraction operation identified an extraordinary alien structure of unknown origin and massive scale — clearly pre-dating any known civilization, clearly worth controlling. The weapon's functionality was dormant or beyond the survey team's ability to interpret. Hegemony knew they were sitting on something extraordinary. They didn't know it still worked. Hegemony said nothing. They built a waypoint on top of it and waited. The superintendent's posting is not coincidental.
 
 **Publicly want:** Operational stability, debt repayment, access to the new Keth trade lanes.
 
 **Actually want:** Quiet ownership of the ancient site under the station. Whatever is down there — they want to own it, not understand it. More specifically: Hegemony's buried survey found not just the structure, but a shutdown mechanism — a control interface the survey team documented but couldn't interpret. Hegemony has spent years quietly studying it. By Act 3, they understand it well enough to use it. This is Harlan's bargaining chip: not a threat, not institutional pressure — the only known way to stop a weapon that will otherwise destroy the station and everyone on it.
 
-**Posture toward the station:** Hegemony already has monitoring equipment on the station, watching for activation events. The commander's reports are being read very carefully. Communications from Hegemony to the commander are friendly but slightly too specific to be routine.
+**Posture toward the station:** Hegemony already has monitoring equipment on the station, watching for activation events. The superintendent's reports are being read very carefully. Communications from Hegemony to the superintendent are friendly but slightly too specific to be routine.
 
 ---
 
@@ -224,7 +224,7 @@ The Unbound are species that were never organized into empires or governments: c
 
 **How they navigate the Frontier:** Wherever the big powers don't bother to look. Information brokerage, access facilitation, transit through complicated jurisdictions. A Maevet collective that has been through a region knows it better than any government map.
 
-**Note on Quen:** Has been on Outpost Nova 15+ years — longer than any other current crew member. Chose to stay, which for a Maevet is significant. What Quen saw when it sealed the Derelict door is the reason it stopped asking questions. Its arc is whether the commander's investigation reopens that question.
+**Note on Quen:** Has been on Outpost Nova 15+ years — longer than any other current crew member. Chose to stay, which for a Maevet is significant. What Quen saw when it sealed the Derelict door is the reason it stopped asking questions. Its arc is whether the superintendent's investigation reopens that question.
 
 ---
 
@@ -368,7 +368,7 @@ The Keeper caste's response was to refer the matter to the Merchant caste leader
 
 Vaen departed. "Here" is away from Keth society. But departure was not passivity.
 
-What drew Vaen to this specific trade lane: a spike in Builder emissions, detectable when the commander first goes deep into the Derelict and triggers the weapon's charging sequence. Vaen has been monitoring Builder signal patterns for years. When the spike hit, they redirected immediately. They arrived presenting themselves as a trader on the new lane — they do not immediately reveal why they came.
+What drew Vaen to this specific trade lane: a spike in Builder emissions, detectable when the superintendent first goes deep into the Derelict and triggers the weapon's charging sequence. Vaen has been monitoring Builder signal patterns for years. When the spike hit, they redirected immediately. They arrived presenting themselves as a trader on the new lane — they do not immediately reveal why they came.
 
 What Vaen carries: a physical artifact found at the secondary Builder ruins site. Unlike coordinates, the artifact is unreadable without context — it is a fragment of Builder notation that describes a target in relative, geometric terms. The weapon's architecture is the decoder ring. When Vaen encounters the weapon's structure, the artifact resolves. The recognition is not of coordinates — it is of the artifact suddenly making sense. The second beat, working out what location it resolves to, happens privately.
 


### PR DESCRIPTION
## Summary
- Sweeps all 14 documentation and dialogue files to use "Station Superintendent" as the PC's official title and "Chief" as the earned crew address
- Adds Deadwood to the TV & Film influences table in `docs/vision.md`; documents Velreth's independent-practitioner employment model (Doc Cochrane reference) and Quen's station-level contract (no Hegemony lever in Act 3)
- Updates the `run` skill with the correct yarn-modified worktree compile sequence (`dotnet build` → delete `.import` → `godot --headless --import`, no restore from main repo)

## Test Plan
- [x] GUT tests pass headlessly (33/33)
- [x] Visual smoketest confirmed — dialogue starts, Quen's line reads "superintendent", Velreth's reads "superintendents"
- [x] `grep -rin "commander" docs/ data/dialogue/` returns zero hits (AC9)
- [x] All 9 acceptance criteria from issue #74 verified

Closes #74