### PR TITLE
feat: inner voice register alignment (issue #83)

### DIFF
--- a/data/dialogue/dex.yarn
+++ b/data/dialogue/dex.yarn
@@ -17,8 +17,8 @@ Dex: I'm Dex. I keep the systems from eating themselves. So far, so good.
 -> Fair enough. #register:detached
     <<register detached>>
     Dex: Fair enough is about the best you can hope for out here.
--> You sound like you've been here a while. #register:sharp
-    <<register sharp>>
+-> You sound like you've been here a while. #register:cynical
+    <<register cynical>>
     Dex: Long enough to know where the bodies are buried. Metaphorically. Probably.
 <<log_action "Checked in with Dex">>
 <<flag met_dex>>

--- a/data/dialogue/dex.yarn
+++ b/data/dialogue/dex.yarn
@@ -20,6 +20,8 @@ Dex: I'm Dex. I keep the systems from eating themselves. So far, so good.
 -> You sound like you've been here a while. #register:cynical
     <<register cynical>>
     Dex: Long enough to know where the bodies are buried. Metaphorically. Probably.
+-> Same assignment, different face. #inner_voice #register:cynical
+    <<register cynical>>
 <<log_action "Checked in with Dex">>
 <<flag met_dex>>
 ===

--- a/data/dialogue/maris.yarn
+++ b/data/dialogue/maris.yarn
@@ -20,6 +20,8 @@ Maris: Don't let the name fool you, it actually makes real food. Mostly.
 -> ...right. #register:detached
     <<register detached>>
     Maris: ...okay then.
+-> Something in her voice says she means it. #inner_voice #register:hopeful
+    <<register hopeful>>
 <<log_action "Met Maris">>
 <<flag met_maris>>
 ===

--- a/data/dialogue/quen.yarn
+++ b/data/dialogue/quen.yarn
@@ -21,6 +21,8 @@ Quen: What Hegemony has given you, Superintendent, is a report. What I carry is 
 -> Fine. #register:detached
     <<register detached>>
     Quen: [beat] Yes. That is often how it begins.
+-> Fifteen years. They've been carrying this alone. #inner_voice #register:warm
+    <<register warm>>
 <<log_action "Spoke with Quen">>
 <<flag met_quen>>
 ===

--- a/data/dialogue/sable.yarn
+++ b/data/dialogue/sable.yarn
@@ -16,5 +16,7 @@ Sable: ...you're going to ask, aren't you.
 -> Sure. #register:detached
     <<register detached>>
     Sable: ...hm. Maybe you're alright.
+-> Everyone out here is waiting for something to go wrong. #inner_voice #register:bitter
+    <<register bitter>>
 <<log_action "Met Sable">>
 ===

--- a/data/dialogue/velreth.yarn
+++ b/data/dialogue/velreth.yarn
@@ -19,6 +19,8 @@ Velreth: You are not injured. That is, statistically speaking, the least common 
 -> I'll come back when I need something. #register:detached
     <<register detached>>
     Velreth: [beat] That is what most people say. I will be here.
+-> There's more here than they're saying. #inner_voice #register:curious
+    <<register curious>>
 <<log_action "Met Velreth">>
 <<flag met_velreth>>
 ===

--- a/docs/characters/npcs.md
+++ b/docs/characters/npcs.md
@@ -30,11 +30,11 @@ The ruins are a genuine discovery. The superintendent did not know about the bur
 
 **Backgrounds (player choice):**
 
-| Background | Inner Voice | Starting resource | Why they're here | Why they're suspicious |
-|------------|-------------|-------------------|-----------------|----------------------|
-| Engineer | The Head (logical, analytical) | Parts | Hegemony needed someone to assess technical state | They've seen Hegemony's surveys — they know what "assess viability" really means |
-| Medic | The Heart (empathetic, perceptive) | Rations | Hegemony framed it as humanitarian | They've watched Hegemony's "support" displace communities before |
-| Drifter | The Edge (instinctive, blunt) | Energy Cells | Hegemony offered stability in exchange for a report | They've survived corporate exploitation; they recognize the shape of it |
+| Background | Starting resource | Why they're here | Why they're suspicious |
+|------------|-------------------|-----------------|----------------------|
+| Engineer | Parts | Hegemony needed someone to assess technical state | They've seen Hegemony's surveys — they know what "assess viability" really means |
+| Medic | Rations | Hegemony framed it as humanitarian | They've watched Hegemony's "support" displace communities before |
+| Drifter | Energy Cells | Hegemony offered stability in exchange for a report | They've survived corporate exploitation; they recognize the shape of it |
 
 ---
 

--- a/scripts/autoload/game_state.gd
+++ b/scripts/autoload/game_state.gd
@@ -14,6 +14,12 @@ const _PAIR_STATE_LABELS: Dictionary = {
 	PairState.BONDED:    "Bonded",
 }
 
+const _AXIS_POLES: Dictionary = {
+	"future":  ["hopeful", "cynical"],
+	"people":  ["warm", "detached"],
+	"unknown": ["curious", "bitter"],
+}
+
 const DEFAULT_PAIR_STATES: Dictionary = {
 	"maris_velreth": PairState.COLLEGIAL,
 	"dex_velreth":   PairState.COLLEGIAL,
@@ -103,6 +109,12 @@ func record_register(register: String) -> void:
 
 func get_register_history() -> Dictionary:
 	return _register_history.duplicate()
+
+func get_alignment_axis(axis: String) -> int:
+	var poles: Array = _AXIS_POLES.get(axis, [])
+	if poles.is_empty():
+		return 0
+	return _register_history.get(poles[0], 0) - _register_history.get(poles[1], 0)
 
 func set_flag_on(flag_id: String) -> void:
 	set_flag(flag_id, true)

--- a/scripts/ui/dialogue_box.gd
+++ b/scripts/ui/dialogue_box.gd
@@ -178,6 +178,8 @@ func _build_choices(options: Array, on_option_selected: Callable) -> void:
 		lbl.mouse_filter = Control.MOUSE_FILTER_STOP
 		lbl.add_theme_font_override("normal_font", load("res://data/fonts/m5x7.tres"))
 		lbl.add_theme_font_size_override("normal_font_size", 13)
+		lbl.add_theme_font_override("italics_font", load("res://data/fonts/m5x7.tres"))
+		lbl.add_theme_font_size_override("italics_font_size", 13)
 		lbl.text = display
 		lbl.set_meta("option_id", option.dialogue_option_id)
 		lbl.set_meta("on_option_selected", on_option_selected)

--- a/scripts/ui/dialogue_box.gd
+++ b/scripts/ui/dialogue_box.gd
@@ -74,18 +74,18 @@ func _unhandled_input(event: InputEvent) -> void:
 				_line_advance_requested.emit()
 		get_viewport().set_input_as_handled()
 	if _state == _State.CHOOSING:
-		var buttons := _choices_container.get_children()
+		var labels := _choices_container.get_children()
 		if event.is_action_pressed("ui_up"):
-			_move_selection(buttons, -1)
+			_move_selection(labels, -1)
 			get_viewport().set_input_as_handled()
 		elif event.is_action_pressed("ui_down"):
-			_move_selection(buttons, 1)
+			_move_selection(labels, 1)
 			get_viewport().set_input_as_handled()
 		else:
-			for i in range(min(4, buttons.size())):
+			for i in range(min(4, labels.size())):
 				if event is InputEventKey and event.pressed and \
 				   event.keycode == KEY_1 + i:
-					_select_choice(buttons[i])
+					_select_choice(labels[i])
 					get_viewport().set_input_as_handled()
 
 # ── YarnSpinner GDScript view protocol ───────────────────────────────────────
@@ -104,12 +104,10 @@ func run_line_async(line: Dictionary) -> void:
 	await _line_advance_requested
 
 func run_options_async(options: Array, on_option_selected: Callable) -> void:
-	push_warning("run_options_async called, options count: %d" % options.size())
 	_dialogue_text.visible = false
 	_speaker_label.visible = false
 	_build_choices(options, on_option_selected)
 	_choices_container.visible = true
-	push_warning("choices_container children: %d, visible: %s" % [_choices_container.get_child_count(), _choices_container.visible])
 	_state = _State.CHOOSING
 	await _option_chosen
 	_dialogue_text.visible = true
@@ -145,50 +143,85 @@ func _make_atlas(index: int) -> AtlasTexture:
 	return atlas
 
 func _build_choices(options: Array, on_option_selected: Callable) -> void:
-	push_warning("_build_choices called, options: %d" % options.size())
 	for child in _choices_container.get_children():
 		child.queue_free()
 	for i in range(options.size()):
-		push_warning("option[%d] keys: %s" % [i, str(options[i].keys())])
 		var option := YarnSpinner.DialogueOption.from_dictionary(options[i])
 		if option == null:
-			push_warning("option %d is null!" % i)
 			continue
-		push_warning("option %d text: %s" % [i, option.line.text_without_character_name.text])
-		var btn := Button.new()
-		var pair_label := ""
+		var text := option.line.text_without_character_name.text
+		var is_inner_voice := false
+		var tag_label := ""
 		for tag in option.line.metadata:
 			var tag_s: String = str(tag)
-			if tag_s.begins_with("pair:"):
+			if tag_s == "inner_voice":
+				is_inner_voice = true
+			elif tag_s.begins_with("register:"):
+				tag_label = "[%s] " % tag_s.substr(9).capitalize()
+			elif tag_s.begins_with("pair:"):
 				var pair_id: String = tag_s.substr(5)
 				var state := GameState.get_pair_state(pair_id)
-				pair_label = "[%s] " % GameState.get_pair_state_label(state)
-				break
-		btn.text = "[%d] %s%s" % [i + 1, pair_label, option.line.text_without_character_name.text]
-		btn.add_theme_font_override("font", load("res://data/fonts/m5x7.tres"))
-		btn.add_theme_font_size_override("font_size", 13)
-		btn.disabled = not option.is_available
-		btn.pressed.connect(_on_choice_pressed.bind(option.dialogue_option_id, on_option_selected))
-		_choices_container.add_child(btn)
+				tag_label = "[%s] " % GameState.get_pair_state_label(state)
+		var body: String
+		if is_inner_voice:
+			body = "[i]… %s%s[/i]" % [tag_label, text]
+		else:
+			body = "%s%s" % [tag_label, text]
+		var display: String = "%d  %s" % [i + 1, body]
+		if not option.is_available:
+			display = "[color=#808080]%s[/color]" % display
+		var lbl := RichTextLabel.new()
+		lbl.bbcode_enabled = true
+		lbl.fit_content = true
+		lbl.scroll_active = false
+		lbl.focus_mode = Control.FOCUS_ALL
+		lbl.mouse_filter = Control.MOUSE_FILTER_STOP
+		lbl.add_theme_font_override("normal_font", load("res://data/fonts/m5x7.tres"))
+		lbl.add_theme_font_size_override("normal_font_size", 13)
+		lbl.text = display
+		lbl.set_meta("option_id", option.dialogue_option_id)
+		lbl.set_meta("on_option_selected", on_option_selected)
+		lbl.set_meta("is_available", option.is_available)
+		if option.is_available:
+			lbl.gui_input.connect(_on_choice_gui_input.bind(lbl))
+		lbl.focus_entered.connect(_on_label_focus_entered.bind(lbl))
+		lbl.focus_exited.connect(_on_label_focus_exited.bind(lbl))
+		_choices_container.add_child(lbl)
 	for child in _choices_container.get_children():
-		if not child.disabled:
+		if child.focus_mode != Control.FOCUS_NONE:
 			child.grab_focus()
 			break
 
-func _on_choice_pressed(option_id: int, on_option_selected: Callable) -> void:
+func _on_choice_gui_input(event: InputEvent, lbl: RichTextLabel) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		_commit_choice(lbl)
+		get_viewport().set_input_as_handled()
+
+func _on_label_focus_entered(lbl: RichTextLabel) -> void:
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(1, 1, 1, 0.08)
+	sb.border_color = Color(1, 1, 1, 0.4)
+	sb.set_border_width_all(1)
+	lbl.add_theme_stylebox_override("normal", sb)
+
+func _on_label_focus_exited(lbl: RichTextLabel) -> void:
+	lbl.remove_theme_stylebox_override("normal")
+
+func _commit_choice(lbl: RichTextLabel) -> void:
+	if not lbl.get_meta("is_available", false):
+		return
 	_state = _State.IDLE
 	_choices_container.visible = false
-	on_option_selected.call(option_id)
+	lbl.get_meta("on_option_selected").call(lbl.get_meta("option_id"))
 	_option_chosen.emit()
 
-func _move_selection(buttons: Array, direction: int) -> void:
+func _move_selection(labels: Array, direction: int) -> void:
 	var focused := _choices_container.get_viewport().gui_get_focus_owner()
-	var current_idx := buttons.find(focused)
+	var current_idx := labels.find(focused)
 	if current_idx == -1:
 		current_idx = 0
-	var next_idx := wrapi(current_idx + direction, 0, buttons.size())
-	buttons[next_idx].grab_focus()
+	var next_idx := wrapi(current_idx + direction, 0, labels.size())
+	labels[next_idx].grab_focus()
 
-func _select_choice(btn: Button) -> void:
-	if not btn.disabled:
-		btn.emit_signal("pressed")
+func _select_choice(lbl: RichTextLabel) -> void:
+	_commit_choice(lbl)

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -159,3 +159,58 @@ func test_pair_state_normalizes_order():
 	GameState.reset()
 	GameState.set_pair_state("velreth_maris", GameState.PairState.TENSION)
 	assert_eq(GameState.get_pair_state("maris_velreth"), GameState.PairState.TENSION)
+
+# --- alignment axis tests ---
+
+func test_alignment_axis_people_empty_returns_zero():
+	GameState.reset()
+	assert_eq(GameState.get_alignment_axis("people"), 0)
+
+func test_alignment_axis_people_warm_dominant():
+	GameState.reset()
+	GameState.record_register("warm")
+	GameState.record_register("warm")
+	GameState.record_register("detached")
+	assert_eq(GameState.get_alignment_axis("people"), 1)
+
+func test_alignment_axis_people_detached_dominant():
+	GameState.reset()
+	GameState.record_register("detached")
+	GameState.record_register("detached")
+	assert_eq(GameState.get_alignment_axis("people"), -2)
+
+func test_alignment_axis_future_hopeful_dominant():
+	GameState.reset()
+	GameState.record_register("hopeful")
+	GameState.record_register("hopeful")
+	GameState.record_register("cynical")
+	assert_eq(GameState.get_alignment_axis("future"), 1)
+
+func test_alignment_axis_future_cynical_dominant():
+	GameState.reset()
+	GameState.record_register("cynical")
+	GameState.record_register("cynical")
+	assert_eq(GameState.get_alignment_axis("future"), -2)
+
+func test_alignment_axis_unknown_curious_dominant():
+	GameState.reset()
+	GameState.record_register("curious")
+	GameState.record_register("bitter")
+	GameState.record_register("bitter")
+	assert_eq(GameState.get_alignment_axis("unknown"), -1)
+
+func test_alignment_axis_unknown_bitter_dominant():
+	GameState.reset()
+	GameState.record_register("bitter")
+	GameState.record_register("bitter")
+	assert_eq(GameState.get_alignment_axis("unknown"), -2)
+
+func test_alignment_axis_unrelated_poles_dont_affect_other_axes():
+	GameState.reset()
+	GameState.record_register("warm")
+	GameState.record_register("hopeful")
+	assert_eq(GameState.get_alignment_axis("unknown"), 0)
+
+func test_alignment_axis_invalid_axis_returns_zero():
+	GameState.reset()
+	assert_eq(GameState.get_alignment_axis("invalid_axis"), 0)


### PR DESCRIPTION
## Summary
- Adds `get_alignment_axis()` to `GameState` with `_AXIS_POLES` constant mapping future/people/unknown axes to register pole pairs
- Replaces `Button` with BBCode-capable `RichTextLabel` in choice list, enabling italic inner voice rendering (`… [Register] text`) and visible register label prefixes on all choices
- Adds one inner voice option (4th choice) to all 5 Day 1 Yarn conversations; retires `#register:sharp` → remapped to `cynical` in `dex.yarn`; removes stale Inner Voice column from `docs/characters/npcs.md`

## Test Plan
- [x] GUT tests pass headlessly (71 tests, 9 new for `get_alignment_axis()`)
- [x] Visual smoketest confirmed — inner voice options render in italics at correct size, register labels visible, mouse/keyboard input working

Closes #83