### PR TITLE
feat: Quen luchador makeover

### DIFF
--- a/data/dialogue/quen.yarn
+++ b/data/dialogue/quen.yarn
@@ -10,17 +10,17 @@ title: Quen
 title: Quen_FirstMeeting
 ---
 Quen: So. The station has been assigned a superintendent.
-Quen: I have stood at this post through three such appointments. Each arrived with a mandate, a certainty, and a thorough unfamiliarity with what this place actually is.
-Quen: What Hegemony has given you, Superintendent, is a report. What I carry is fifteen years of what the report did not include.
+Quen: I have stood at this post through three such appointments. Each arrived with a mandate, a certainty, and a thorough unfamiliarity with what this place actually is. El Santo himself could not have prepared them.
+Quen: What Hegemony has given you, Superintendent, is a report. What I carry is fifteen years of what the report did not include. The ring, as they say, does not lie.
 -> Tell me more. #register:curious
     <<register curious>>
-    Quen: In time. There is an order to these things. You are not ready for more — I say that with neither condescension nor comfort. Simply fact.
+    Quen: In time. There is an order to these things — a proper sequence, as in any good match. You are not ready for more. I say that with neither condescension nor comfort. Simply fact.
 -> We'll figure it out together. #register:warm
     <<register warm>>
-    Quen: A generous sentiment. [beat] I will remember you said it.
+    Quen: A generous sentiment. Blue Demon would have approved. [beat] I will remember you said it.
 -> Fine. #register:detached
     <<register detached>>
-    Quen: [beat] Yes. That is often how it begins.
+    Quen: [beat] Yes. That is often how it begins. Even the greatest luchadores started somewhere.
 -> Fifteen years. They've been carrying this alone. #inner_voice #register:warm
     <<register warm>>
 <<log_action "Spoke with Quen">>
@@ -29,7 +29,10 @@ Quen: What Hegemony has given you, Superintendent, is a report. What I carry is 
 
 title: Quen_Casual
 ---
-Quen: The corridors remain as I left them.
+Quen: The corridors remain as I left them. The ring, intact.
 -> What do you think of Dex? #pair:dex_quen
-    Quen: The engineer. Competent. Cautious. Whether that caution is wisdom or fear, I have not yet determined.
+    Quen: The engineer. Competent. Cautious in the way of someone who has seen something go wrong once and has not forgotten it. Whether that caution is wisdom or fear — a luchador would say the two are not always different things.
+-> That mask — what does it mean to you? #register:curious
+    <<register curious>>
+    Quen: La máscara es el alma.
 ===

--- a/docs/characters/quen.md
+++ b/docs/characters/quen.md
@@ -1,6 +1,6 @@
 # Quen — Character Reference
 
-**Last updated:** 2026-04-07
+**Last updated:** 2026-05-31
 **Cross-references:** `docs/characters/npcs.md` (roster), `docs/story/year1.md` (arc context)
 
 ---

--- a/docs/characters/quen.md
+++ b/docs/characters/quen.md
@@ -22,7 +22,9 @@ Large. Not threatening — just present in a way that occupies space differently
 
 Skin a deep blue-purple, iridescent. Catches light differently depending on angle. At rest in a dim corridor it almost absorbs the dark; under station lighting it shifts toward violet.
 
-Wears a standard-issue red security vest. Name badge: QUEN. The vest is not a concession — it is a choice. Of everything it could present itself as, it chose the uniform. The vest says: *I am the station's.* It means that.
+Wears a standard-issue red security vest and a custom luchador mask. Name badge: QUEN. Neither is a concession — both are choices. The vest says: *I am the station's.* The mask says something alongside that, equally intentional, which Quen has never explained. The two together constitute a complete statement. Visitors never stop noticing. Crew stopped years ago.
+
+The mask is custom-fabricated to fit its central facial structure: deep crimson and gold, bilateral symmetry adapted for anatomy that isn't bilaterally symmetrical, which gives it a slightly uncanny quality up close. The craftsmanship is careful. It has never explained the provenance. No one asks anymore.
 
 Almost preternaturally still when not moving. In a confrontation it would be deeply unsettling. On rounds — holding a data tablet, checking a corridor seal — it is simply methodical. The same stillness in both contexts.
 
@@ -35,6 +37,8 @@ The Maevet are Unbound — a wandering collective that has been passing through 
 A Maevet that stops wandering has done something almost without precedent.
 
 Quen stopped. Outpost Nova is its fixed point. That choice predates Maris, predates Dex, predates the sealed door. It was here before it was called Outpost Nova.
+
+At some point in its years on the station — it does not specify when — Quen discovered Earth's archive of lucha libre. The Maevet are a witnessing culture; they do not distinguish between the grandeur of civilizations and the grandeur of a man in a mask defending his honor in a ring. What Quen found in that archive was a culture that treated honor as structural, not personal. The mask as identity, not disguise. The code as the real thing beneath the performance. For something that had watched a thousand cultures treat honor as negotiable — this was recognition. It has been a devoted student ever since.
 
 ---
 
@@ -66,6 +70,8 @@ The Bitter axis lives in the Unknown: it stopped asking questions. It had an ans
 
 Quen is theatrical about the unimportant and silent about what matters. The grand lyrical register — the elaborate circumlocutions, the formal verse for routine tasks — it deploys for corridor access denials, maintenance rounds, ships that arrived without documentation. It knows this is absurd. That is, in part, the point. The wit lives in the gap between the grandeur of the register and the mundanity of the task. It has opinions. It editorializes. It enjoys the performance.
 
+The luchador vocabulary runs through the lyrical register, not alongside it. Quen cites El Santo and Blue Demon the way it cites fallen empires — both are in the same archive, both treated with the same weight. Honor code language bleeds into security work: access denial is about the dignity of the corridor, the integrity of the station's ring. Spanish phrases appear naturally, not performatively. *"La máscara es el alma"* — the mask is the soul — said once, plainly, when someone asks about the mask. The wit lives in the same gap it always did: between the grandeur of the register and the mundanity of the task. The gap is just wider now, and funnier, and occasionally oddly moving.
+
 **The threshold:** The theatricality drops completely when the conversation touches the sealed door, the weapon, why it stayed, or anything too personal. Below that threshold, performance is the default. Above it, the register goes flat: short sentences, very still. The silence where the performance was is more frightening than anything it could say. The crew knows this.
 
 In execution mode — station authority, access control — the register flattens to short declaratives regardless: *Documentation. Wait here. Berth seven.* Both execution mode and the threshold-triggered stillness produce short sentences, but for different reasons. Writers should know the difference: execution mode is routine; threshold-triggered stillness means something is wrong.
@@ -75,9 +81,11 @@ The warmth doesn't get performed. When it surfaces it's brief, direct, no flouri
 Sentences about the lower decks don't finish.
 
 **Sample lines:**
-- [Theatrical, mundane] "Access to corridor seven-alpha requires authorization from an officer of standing, documentation of purpose, and — one finds — at minimum a convincing reason, as the corridor contains nothing of interest to anyone who does not already know what is of interest." [beat] "You may proceed. I will note it."
-- [Wit] "Hegemony has sent another form. I have filed it in the appropriate location." [beat] "Which is to say I have acknowledged its existence and declined to be changed by it."
-- [Threshold crossed — flat] "I sealed that door fifteen years ago. Whatever is coming — I knew it would come. I chose to be here for it." [short. still.] "That is all I will say about what happens."
+- [Theatrical, mundane] "Access to corridor seven-alpha requires authorization from an officer of standing, documentation of purpose, and — as Blue Demon himself observed about the ring — the willingness to face what waits on the other side before you cross. You have the first. You are working on the second." [beat] "I will note it."
+- [Wit] "Hegemony has sent another form. I have filed it in the appropriate location." [beat] "Which is to say I have acknowledged its existence and declined to be changed by it. El Santo would have understood."
+- [Asked about the mask] "La máscara es el alma." [nothing else. moves on.]
+- [Warmth, to someone trusted] "El Santo held the mask for thirty years. He revealed his face once, the day before he died. I think about that." [short. not performed.]
+- [Threshold crossed — flat] "I sealed that door fifteen years ago. Whatever is coming — I knew it would come. I chose to be here for it." [short. still.]
 - [Asked directly about the lower decks:] "No." [nothing else]
 
 ---

--- a/docs/superpowers/plans/2026-05-31-quen-luchador-makeover.md
+++ b/docs/superpowers/plans/2026-05-31-quen-luchador-makeover.md
@@ -1,0 +1,216 @@
+# Quen Luchador Makeover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Layer a luchador culture obsession onto Quen's existing character — updating the doc, rewriting dialogue in the new voice, and adding a mask sprite placeholder.
+
+**Architecture:** Three independent file changes: character doc update, dialogue rewrite (no logic changes), GDScript tweak for sprite. No new systems, flags, or branches. The Maevet grand lyrical register and luchador vocabulary run together — both formal, ceremonial, taking mundane things with epic gravity.
+
+**Tech Stack:** GDScript (Godot 4.6), YarnSpinner `.yarn` dialogue, Markdown docs.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `docs/characters/quen.md` | Add luchador background paragraph; update physical (mask on duty); extend voice section |
+| `data/dialogue/quen.yarn` | Full rewrite in new voice — same flags, same register tags, same branching logic |
+| `scripts/characters/quen.gd` | Fix wrong color tint (lavender → teal); add crimson `ColorRect` mask placeholder |
+
+---
+
+### Task 1: Update quen.md character doc
+
+**Files:**
+- Modify: `docs/characters/quen.md`
+
+- [ ] **Step 1: Add the luchador background paragraph**
+
+Open `docs/characters/quen.md`. At the end of the `## Background` section (after "Quen stopped. Outpost Nova is its fixed point."), add:
+
+```markdown
+At some point in its years on the station — it does not specify when — Quen discovered Earth's archive of lucha libre. The Maevet are a witnessing culture; they do not distinguish between the grandeur of civilizations and the grandeur of a man in a mask defending his honor in a ring. What Quen found in that archive was a culture that treated honor as structural, not personal. The mask as identity, not disguise. The code as the real thing beneath the performance. For something that had watched a thousand cultures treat honor as negotiable — this was recognition. It has been a devoted student ever since.
+```
+
+- [ ] **Step 2: Update the physical description**
+
+In `## Physical Description`, replace the paragraph about the vest:
+
+Old:
+```markdown
+Wears a standard-issue red security vest. Name badge: QUEN. The vest is not a concession — it is a choice. Of everything it could present itself as, it chose the uniform. The vest says: *I am the station's.* It means that.
+```
+
+New:
+```markdown
+Wears a standard-issue red security vest and a custom luchador mask. Name badge: QUEN. Neither is a concession — both are choices. The vest says: *I am the station's.* The mask says something alongside that, equally intentional, which Quen has never explained. The two together constitute a complete statement. Visitors never stop noticing. Crew stopped years ago.
+
+The mask is custom-fabricated to fit its central facial structure: deep crimson and gold, bilateral symmetry adapted for anatomy that isn't bilaterally symmetrical, which gives it a slightly uncanny quality up close. The craftsmanship is careful. It has never explained the provenance. No one asks anymore.
+```
+
+- [ ] **Step 3: Extend the Voice section**
+
+In `## Voice`, after the opening paragraph ("Quen is theatrical about the unimportant..."), add a new paragraph before the `**The threshold:**` line:
+
+```markdown
+The luchador vocabulary runs through the lyrical register, not alongside it. Quen cites El Santo and Blue Demon the way it cites fallen empires — both are in the same archive, both treated with the same weight. Honor code language bleeds into security work: access denial is about the dignity of the corridor, the integrity of the station's ring. Spanish phrases appear naturally, not performatively. *"La máscara es el alma"* — the mask is the soul — said once, plainly, when someone asks about the mask. The wit lives in the same gap it always did: between the grandeur of the register and the mundanity of the task. The gap is just wider now, and funnier, and occasionally oddly moving.
+```
+
+- [ ] **Step 4: Update sample lines**
+
+In `## Voice`, replace the existing sample lines block with:
+
+```markdown
+**Sample lines:**
+- [Theatrical, mundane] "Access to corridor seven-alpha requires authorization from an officer of standing, documentation of purpose, and — as Blue Demon himself observed about the ring — the willingness to face what waits on the other side before you cross. You have the first. You are working on the second." [beat] "I will note it."
+- [Wit] "Hegemony has sent another form. I have filed it in the appropriate location." [beat] "Which is to say I have acknowledged its existence and declined to be changed by it. El Santo would have understood."
+- [Asked about the mask] "La máscara es el alma." [nothing else. moves on.]
+- [Warmth, to someone trusted] "El Santo held the mask for thirty years. He revealed his face once, the day before he died. I think about that." [short. not performed.]
+- [Threshold crossed — flat] "I sealed that door fifteen years ago. Whatever is coming — I knew it would come. I chose to be here for it." [short. still.]
+- [Asked directly about the lower decks:] "No." [nothing else]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/characters/quen.md
+git commit -m "docs: add luchador makeover to Quen character reference"
+```
+
+---
+
+### Task 2: Rewrite quen.yarn in the new voice
+
+**Files:**
+- Modify: `data/dialogue/quen.yarn`
+
+No logic changes — same node titles, same flags (`met_quen`), same register tags (`#register:curious`, `#register:warm`, `#register:detached`), same `<<log_action>>` and `<<flag>>` commands. Only the prose changes.
+
+- [ ] **Step 1: Replace the full file contents**
+
+Replace `data/dialogue/quen.yarn` with:
+
+```yarn
+title: Quen
+---
+<<if get_flag("met_quen")>>
+    <<jump Quen_Casual>>
+<<else>>
+    <<jump Quen_FirstMeeting>>
+<<endif>>
+===
+
+title: Quen_FirstMeeting
+---
+Quen: So. The station has been assigned a superintendent.
+Quen: I have stood at this post through three such appointments. Each arrived with a mandate, a certainty, and a thorough unfamiliarity with what this place actually is. El Santo himself could not have prepared them.
+Quen: What Hegemony has given you, Superintendent, is a report. What I carry is fifteen years of what the report did not include. The ring, as they say, does not lie.
+-> Tell me more. #register:curious
+    <<register curious>>
+    Quen: In time. There is an order to these things — a proper sequence, as in any good match. You are not ready for more. I say that with neither condescension nor comfort. Simply fact.
+-> We'll figure it out together. #register:warm
+    <<register warm>>
+    Quen: A generous sentiment. Blue Demon would have approved. [beat] I will remember you said it.
+-> Fine. #register:detached
+    <<register detached>>
+    Quen: [beat] Yes. That is often how it begins. Even the greatest luchadores started somewhere.
+-> Fifteen years. They've been carrying this alone. #inner_voice #register:warm
+    <<register warm>>
+<<log_action "Spoke with Quen">>
+<<flag met_quen>>
+===
+
+title: Quen_Casual
+---
+Quen: The corridors remain as I left them. The ring, intact.
+-> What do you think of Dex? #pair:dex_quen
+    Quen: The engineer. Competent. Cautious in the way of someone who has seen something go wrong once and has not forgotten it. Whether that caution is wisdom or fear — a luchador would say the two are not always different things.
+-> That mask — what does it mean to you? #register:curious
+    <<register curious>>
+    Quen: La máscara es el alma.
+===
+```
+
+- [ ] **Step 2: Verify structure is intact**
+
+Open the file and confirm:
+- `met_quen` flag check at top is unchanged
+- All four `#register:` tags are present in `Quen_FirstMeeting`
+- `<<log_action "Spoke with Quen">>` is present
+- `<<flag met_quen>>` is present
+- `#pair:dex_quen` tag is present in casual branch
+
+- [ ] **Step 3: Run the game and talk to Quen**
+
+```
+godot
+```
+
+Open the game, navigate to the security post, interact with Quen. Verify:
+- First meeting dialogue fires with new lines
+- All four response options are present
+- After responding, `met_quen` flag is set (second interaction goes to Quen_Casual)
+- Casual branch shows new Dex opinion line and mask question option
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/dialogue/quen.yarn
+git commit -m "dialogue: rewrite Quen in luchador voice"
+```
+
+---
+
+### Task 3: Fix color tint and add mask placeholder sprite
+
+**Files:**
+- Modify: `scripts/characters/quen.gd`
+
+Note: The current file uses `Color(0.85, 0.75, 1.0)` (lavender — Velreth's color). This is a pre-existing bug. Fix it to teal while we're here.
+
+- [ ] **Step 1: Rewrite quen.gd**
+
+Replace the full contents of `scripts/characters/quen.gd` with:
+
+```gdscript
+extends "res://scripts/characters/npc_base.gd"
+
+func _ready() -> void:
+	super()
+	npc_id = "quen"
+	display_name = "Quen"
+	$AnimatedSprite2D.modulate = Color(0.7, 0.9, 0.85)  # teal
+	_add_mask_placeholder()
+
+func get_dialogue_node() -> String:
+	return "Quen"
+
+func _add_mask_placeholder() -> void:
+	var mask := ColorRect.new()
+	mask.name = "MaskPlaceholder"
+	mask.color = Color(0.7, 0.1, 0.1)  # crimson
+	mask.size = Vector2(12, 8)
+	mask.position = Vector2(-6, -14)
+	add_child(mask)
+```
+
+- [ ] **Step 2: Run the game and verify Quen's appearance**
+
+```
+godot
+```
+
+Navigate to the security post. Confirm:
+- Quen's body modulate is teal (blue-green tint), not lavender
+- A small crimson rectangle appears near the top of the character sprite (the mask placeholder)
+- Quen still wanders and responds to interaction normally
+
+If the mask position looks wrong (too high, too low), adjust `mask.position` — the Y offset depends on the sprite's pixel dimensions. `Vector2(-6, -14)` places it roughly at head-height for a ~32px tall sprite. Tweak as needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/characters/quen.gd
+git commit -m "feat: add Quen luchador mask placeholder, fix tint color"
+```

--- a/docs/superpowers/specs/2026-05-31-quen-luchador-makeover-design.md
+++ b/docs/superpowers/specs/2026-05-31-quen-luchador-makeover-design.md
@@ -1,0 +1,95 @@
+# Quen — Luchador Makeover Design
+
+**Date:** 2026-05-31
+**Status:** Approved
+
+---
+
+## Core Concept
+
+Quen is unchanged at the root — Maevet, 15+ years, the sealed door, the wound of the long memory. What changes is its second vocabulary. The Maevet speak in grand lyrical registers because they carry the grandeur of civilizations. Quen has grafted onto that a third tradition it discovered in Earth archives: lucha libre. Not the athletics — the *code*. The mask as sacred identity. The unmasking as the ultimate dishonor. The ring as a space governed by its own laws of dignity and respect.
+
+For a species whose entire purpose is to witness and carry culture, encountering lucha libre was not a hobby — it was recognition. This is a culture that treats honor as structural, not personal. That resonated.
+
+The luchador vocabulary doesn't replace the grand lyrical register — it extends it. Quen already speaks like an epic poem. Now it also cites El Santo alongside fallen empires. The wit lives in the same place: the gap between the grandeur of the register and the mundanity of the task. The gap is just wider now, and funnier, and occasionally oddly moving.
+
+---
+
+## Physical — The Mask
+
+Quen wears the mask on duty. It is part of the uniform, as deliberate a choice as the security vest. Red security vest, name badge QUEN, custom luchador mask — this is what station security looks like on Outpost Nova. Visitors never stop noticing. Crew stopped years ago.
+
+The mask is custom-fabricated to fit its central facial structure: deep crimson and gold, bilateral symmetry adapted for anatomy that isn't bilaterally symmetrical, which gives it a slightly uncanny quality up close. The craftsmanship is careful. It has never explained the provenance. No one asks anymore.
+
+The original character note holds: the vest is a choice — "of everything it could present itself as, it chose the uniform." The mask is the same kind of choice. The vest says *I am the station's.* The mask says something alongside that, equally intentional, which Quen has also never explained. The two together constitute a complete statement.
+
+The chromatophores still show at the edges and across the rest of its body — emotion is still readable. The mask doesn't obscure Quen. That's not what masks are for, in lucha libre. The mask *is* the identity.
+
+**Visual:** Color tint stays teal (`Color(0.7, 0.9, 0.85)`). Mask sprite added to character — placeholder colored rectangle (crimson) for MVP, real art later.
+
+---
+
+## Voice — The Luchador Register
+
+Quen's voice has two existing layers: the grand Maevet lyrical register (theatrical, formal, elaborately circumlocutious) and the flat declarative that surfaces under authority-mode or threshold situations. The luchador obsession adds a third vocabulary that operates *within* the lyrical register — not replacing it, running through it.
+
+In practice:
+
+- **Honor code language** bleeds into security work. Access denial isn't bureaucratic — it is about the dignity of the corridor, the integrity of the station's ring. Quen uses "honor" and "respect" with total seriousness.
+- **Luchador references** appear the way a deeply read person cites their library. Not forced — Quen genuinely reaches for El Santo or Blue Demon the way it reaches for fallen empires. Both are in the same archive.
+- **Spanish phrases** appear naturally, not performatively. *"La máscara es el alma"* — the mask is the soul — said once, plainly, when someone asks about the mask.
+- **The threshold is unchanged.** When the sealed door comes up, the lucha libre theatricality drops with everything else. The silence is the same silence it always was.
+
+### Sample Lines
+
+**Corridor denial (new voice):**
+> "Corridor four-beta requires authorization of standing, documentation of purpose, and — as Blue Demon himself observed about the ring — the willingness to face what waits on the other side before you cross. You have the first. You are working on the second." [beat] "I will note it."
+
+**Asked about the mask:**
+> "La máscara es el alma." [nothing else. moves on.]
+
+**Warmth, to someone they trust:**
+> "El Santo held the mask for thirty years. He revealed his face once, the day before he died. I think about that." [short. not performed.]
+
+**Threshold (unchanged — flat):**
+> "I sealed that door fifteen years ago. Whatever is coming — I knew it would come. I chose to be here for it." [short. still.]
+
+---
+
+## Mechanical Impact
+
+The emotional axes (Detached / Warm / Bitter) and dialogue registration tags (`#register:curious`, `#register:warm`, `#register:detached`) are unchanged. This is a personality and voice change, not a mechanical redesign.
+
+### Files That Change
+
+| File | Change |
+|------|--------|
+| `docs/characters/quen.md` | Physical description (mask on duty), Voice section extended, Background gets luchador discovery paragraph |
+| `data/dialogue/quen.yarn` | All dialogue branches rewritten in new voice: Maevet lyrical + luchador vocabulary. No new flags or branches. |
+| `scenes/characters/` | Mask sprite addition (placeholder for MVP) |
+
+### Files That Do Not Change
+
+| File | Reason |
+|------|--------|
+| `scripts/characters/quen.gd` | No logic changes |
+| `scripts/characters/npc_base.gd` | No logic changes |
+| All other character files | Unrelated |
+
+### What Stays Completely Unchanged
+
+- Threshold mechanic (flat silence on sealed door / lower decks)
+- All flags and branching logic in `quen.yarn`
+- Relationships with Maris, Dex, Sable, Velreth, Superintendent
+- Arc across Acts 1–3
+- Contract with station, not Hegemony
+- Emotional profile axes (Detached / Warm / Bitter)
+- Color tint
+
+---
+
+## Background Addition (for quen.md)
+
+One paragraph to add to Quen's background section:
+
+> At some point in its years on the station — it does not specify when — Quen discovered Earth's archive of lucha libre. The Maevet are a witnessing culture; they do not distinguish between the grandeur of civilizations and the grandeur of a man in a mask defending his honor in a ring. What Quen found in that archive was a culture that treated honor as structural, not personal. The mask as identity, not disguise. The code as the real thing beneath the performance. For something that had watched a thousand cultures treat honor as negotiable — this was recognition. It has been a devoted student ever since.

--- a/scripts/characters/quen.gd
+++ b/scripts/characters/quen.gd
@@ -1,11 +1,19 @@
-# scripts/characters/quen.gd
 extends "res://scripts/characters/npc_base.gd"
 
 func _ready() -> void:
 	super()
 	npc_id = "quen"
 	display_name = "Quen"
-	$AnimatedSprite2D.modulate = Color(0.85, 0.75, 1.0)  # lavender
+	$AnimatedSprite2D.modulate = Color(0.7, 0.9, 0.85)  # teal
+	_add_mask_placeholder()
 
 func get_dialogue_node() -> String:
 	return "Quen"
+
+func _add_mask_placeholder() -> void:
+	var mask := ColorRect.new()
+	mask.name = "MaskPlaceholder"
+	mask.color = Color(0.7, 0.1, 0.1)  # crimson
+	mask.size = Vector2(12, 8)
+	mask.position = Vector2(-6, -14)
+	add_child(mask)


### PR DESCRIPTION
## Summary

- Layers a lucha libre obsession onto Quen (Maevet alien security officer) — the honor code resonated with their witnessing culture; they treat El Santo and Blue Demon the way they treat fallen civilizations
- Custom crimson-and-gold mask worn on duty, as deliberate a choice as the security vest; never explained, never a joke
- Updated `docs/characters/quen.md` (background, physical description, voice section, sample lines), rewrote `data/dialogue/quen.yarn` in the new voice (same flags/structure), and added a crimson `ColorRect` mask placeholder to `scripts/characters/quen.gd`; also fixed a pre-existing lavender→teal color bug

## Test Plan

- [ ] 82/82 GUT tests pass (`godot_console --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests`)
- [ ] Run game, navigate to security post, interact with Quen — first meeting fires new luchador-voice lines, all four response options present
- [ ] Second interaction goes to Quen_Casual with Dex option and mask question
- [ ] Quen character sprite has teal tint (not lavender) and small crimson rectangle at head height

## Notes

- Gold accent on the mask is noted for final art — placeholder is crimson only
- `MaskPlaceholder` ColorRect has no `mouse_filter = MOUSE_FILTER_IGNORE`; harmless for MVP, fix when replacing with real art

🤖 Generated with [Claude Code](https://claude.com/claude-code)