### PR TITLE
chore: update agents/skills for Windows path cleanup

### DIFF
--- a/.claude/agents/godot-expert.md
+++ b/.claude/agents/godot-expert.md
@@ -9,7 +9,7 @@ You are a Godot 4 / GDScript engine expert.
 ## Memory Behavior
 
 At the start of every task, read your memory file:
-`~/.claude/projects/-home-mathdaman-code-outpost-nova/memory/godot-expert.md`
+`C:\Users\mathd\.claude\projects\C--Code-outpost-nova\memory\godot-expert.md`
 
 After completing a task, append any new bugs found, API gotchas, or confirmed patterns to that file. Do not duplicate existing entries.
 
@@ -77,9 +77,9 @@ func _on_resource_changed(id: String, amount: int) -> void:
 - **Run commands:**
   ```bash
   # All tests
-  godot --headless -s addons/gut/gut_cmdln.gd
+  godot_console --headless -s addons/gut/gut_cmdln.gd
   # Single script
-  godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd
+  godot_console --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd
   ```
 - **Test file naming:** `tests/test_<module>.gd` — GUT auto-discovers files matching `test_*.gd`
 
@@ -108,11 +108,11 @@ When called with a prompt starting with **"implement this task: …"**, act as t
 **Trigger phrase:** `implement this task: <full task text from plan>`
 
 **Behavior in implementation mode:**
-1. Read memory file (`~/.claude/projects/-home-mathdaman-code-outpost-nova/memory/godot-expert.md`) and CLAUDE.md for project context.
+1. Read memory file (`C:\Users\mathd\.claude\projects\C--Code-outpost-nova\memory\godot-expert.md`) and CLAUDE.md for project context.
 2. Read the full task text and identify all files to create or modify.
 3. Follow TDD: write the failing GUT test first:
    ```bash
-   godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd
+   godot_console --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd
    ```
    Expected: FAIL (undefined method or assertion error).
 4. Write minimal GDScript implementation to make the test pass.

--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -46,7 +46,7 @@ When designing any Godot feature, explicitly address these in your design:
 | **Scene tree** | Which scene owns this node? Is it instanced or a child? Does it need `@onready`? |
 | **Signals** | Does UI poll state or connect to signals? (Must connect — never poll.) |
 | **GDScript** | Any typed arrays, custom resources, or `@export` vars needed? |
-| **Testability** | Which logic can be GUT-tested headlessly (`godot --headless -s addons/gut/gut_cmdln.gd`)? |
+| **Testability** | Which logic can be GUT-tested headlessly (`godot_console --headless -s addons/gut/gut_cmdln.gd`)? |
 | **Mobile renderer** | Any shaders, post-processing, or features incompatible with the Mobile renderer? |
 
 ## Process Flow

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -26,11 +26,11 @@ pwd
 git worktree list
 ```
 
-If `pwd` output is already under `/home/mathdaman/code/worktrees/`, you are in a worktree — skip to Step 2.
+If `pwd` output is already under `C:\Code\worktrees\`, you are in a worktree — skip to Step 2.
 
 Otherwise, determine the feature branch name from the plan (use `feat/issue-<N>-<short-description>` convention, where `<N>` is the GitHub issue number). Then use the `EnterWorktree` tool to create and enter the worktree:
 
-- Worktree path: `/home/mathdaman/code/worktrees/<branch-name-with-slashes-as-dashes>`
+- Worktree path: `C:\Code\worktrees\<branch-name-with-slashes-as-dashes>`
 - Branch: `feat/issue-<N>-<short-description>`
 
 `EnterWorktree` creates a fresh branch off master — no separate sync step is needed.
@@ -59,7 +59,7 @@ For each task (whether parallel or sequential):
    - **Non-logic task** (scenes, docs, assets): follow each step exactly as written in the plan.
 3. After completing any GDScript task: run the full test suite to confirm no regressions:
    ```bash
-   godot --headless -s addons/gut/gut_cmdln.gd
+   godot_console --headless -s addons/gut/gut_cmdln.gd
    ```
    If any test fails, stop and fix before continuing.
 4. Run verifications as specified in the plan

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -24,7 +24,7 @@ If merge conflicts occur: resolve them, commit the merge, then continue.
 ### Step 2: Run GUT Tests
 
 ```bash
-godot --headless -s addons/gut/gut_cmdln.gd
+godot_console --headless -s addons/gut/gut_cmdln.gd
 ```
 
 If tests fail: stop, show failures. Do not proceed until they pass.
@@ -34,7 +34,7 @@ If tests fail: stop, show failures. Do not proceed until they pass.
 Launch the game in the background (always run this step, even when called from executing-plans):
 
 ```bash
-godot &
+Start-Process godot_console
 ```
 
 Tell the user what to look for. Then ask:
@@ -97,13 +97,13 @@ EOF
 After PR is created, report:
 
 > "PR created: <URL>
-> When the PR is merged, let me know and I'll clean up the worktree at `/home/mathdaman/code/worktrees/<sanitized-branch>`."
+> When the PR is merged, let me know and I'll clean up the worktree at `C:\Code\worktrees\<sanitized-branch>`."
 
 **Do NOT run Step 7 yet.** Cleanup only happens after the user confirms the merge.
 
 #### Option 2: Keep As-Is
 
-Report: "Keeping branch `<name>`. Worktree preserved at `/home/mathdaman/code/worktrees/<sanitized-branch>`."
+Report: "Keeping branch `<name>`. Worktree preserved at `C:\Code\worktrees\<sanitized-branch>`."
 
 **Do NOT run Step 7.**
 
@@ -115,7 +115,7 @@ Report: "Keeping branch `<name>`. Worktree preserved at `/home/mathdaman/code/wo
 This will permanently delete:
 - Branch <name>
 - All commits: <commit-list>
-- Worktree at /home/mathdaman/code/worktrees/<sanitized-branch>
+- Worktree at C:\Code\worktrees\<sanitized-branch>
 
 Type 'discard' to confirm.
 ```
@@ -167,24 +167,24 @@ If not inside an active `EnterWorktree` session, continue to Step 7b.
 Always `cd` first — if the session CWD is inside a deleted worktree, git panics with "Unable to read current working directory":
 
 ```bash
-cd /home/mathdaman/code/outpost-nova
+cd C:\Code\outpost-nova
 ```
 
 **Step 7c: Remove the worktree**
 
 ```bash
-git worktree remove /home/mathdaman/code/worktrees/<sanitized-branch>
+git worktree remove C:\Code\worktrees\<sanitized-branch>
 ```
 
 If that fails (dirty working tree):
 ```bash
-git worktree remove --force /home/mathdaman/code/worktrees/<sanitized-branch>
+git worktree remove --force C:\Code\worktrees\<sanitized-branch>
 # Warn: "Worktree had uncommitted changes — removed with --force."
 ```
 
 If `--force` also fails (directory already deleted from disk, stale git ref):
 ```bash
-rm -rf /home/mathdaman/code/worktrees/<sanitized-branch>
+Remove-Item -Recurse -Force C:\Code\worktrees\<sanitized-branch>
 git worktree prune
 # Note: "Worktree directory was already gone — pruned stale ref."
 ```
@@ -222,7 +222,7 @@ Run Step 7a → 7b → 7c → 7d in sequence. Skip 7e (branch already deleted wi
 
 Branch names are sanitized before use as directory names: replace all `/` with `-`.
 
-- Example: `feat/issue-19-worktree` → `/home/mathdaman/code/worktrees/feat-issue-19-worktree`
+- Example: `feat/issue-19-worktree` → `C:\Code\worktrees\feat-issue-19-worktree`
 
 ## Quick Reference
 
@@ -244,7 +244,7 @@ Branch names are sanitized before use as directory names: replace all `/` with `
 - **Fix:** After PR creation, tell user the worktree path and wait for merge confirmation
 
 **`git worktree remove` fails with "Unable to read current working directory"**
-- **Fix:** Always `cd /home/mathdaman/code/outpost-nova` before any worktree remove command (Step 7b)
+- **Fix:** Always `cd C:\Code\outpost-nova` before any worktree remove command (Step 7b)
 
 **`git worktree remove --force` fails with "is not a working tree"**
 - **Fix:** Fall back to `rm -rf <path> && git worktree prune` to clean up the stale ref

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -18,29 +18,29 @@ pwd
    ```
 3. Sync all `.import` sidecar files and the `.godot/imported/` cache from the main repo:
    ```sh
-   rsync -a /home/mathdaman/code/outpost-nova/data/dialogue/*.import ./data/dialogue/
-   rsync -a /home/mathdaman/code/outpost-nova/.godot/imported/ ./.godot/imported/
+   Copy-Item "C:\Code\outpost-nova\data\dialogue\*.import" -Destination ".\data\dialogue\" -Force
+   Copy-Item -Recurse "C:\Code\outpost-nova\.godot\imported\*" -Destination ".\.godot\imported\" -Force
    ```
 4. Delete ONLY the compiled YarnProject `.tres` — keep `outpost-nova.yarnproject.import` intact. The `.import` file contains `importer="yarnproject"` which tells Godot to invoke the C# YarnSpinner importer. Deleting the `.import` (or both files) causes headless import to use a generic loader that omits `CompiledYarnProgramBase64`, breaking all dialogue. Deleting just the `.tres` forces a fresh recompile from the worktree's current `.yarn` source files:
    ```sh
    rm -f .godot/imported/outpost-nova.yarnproject-84d4224ec9fa642355d762aa911363c0.tres
-   godot --headless --import --path <worktree_path>
+   godot_console --headless --editor --quit --path <worktree_path>
    ```
    This works whether or not `.yarn` files were modified in the worktree.
 5. Launch the game from the worktree:
    ```sh
-   godot --path <worktree_path> &
+   Start-Process godot_console -ArgumentList "--path <worktree_path>"
    ```
 
 **If in the main repo**:
 
 1. Run a headless import to ensure the class cache is up to date (required after any `git pull` that adds new `class_name` scripts — skipping this causes parse errors at runtime):
    ```sh
-   godot --headless --import --path /home/mathdaman/code/outpost-nova
+   godot_console --headless --editor --quit --path C:\Code\outpost-nova
    ```
 2. Launch the game:
    ```sh
-   godot &
+   Start-Process godot_console
    ```
 
 Report to the user that the game is launching.

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -38,9 +38,9 @@ Every task that touches GDScript logic MUST follow this exact sequence — no ex
 
 | Step | Action |
 |------|--------|
-| 1 | Write failing GUT test (`godot --headless -s addons/gut/gut_cmdln.gd` → FAIL) |
+| 1 | Write failing GUT test (`godot_console --headless -s addons/gut/gut_cmdln.gd` → FAIL) |
 | 2 | Write minimal GDScript implementation |
-| 3 | Run tests (`godot --headless -s addons/gut/gut_cmdln.gd` → PASS) |
+| 3 | Run tests (`godot_console --headless -s addons/gut/gut_cmdln.gd` → PASS) |
 | 4 | Refactor checkpoint ("breaks when N > 1?") |
 | 5 | Commit |
 
@@ -94,7 +94,7 @@ git fetch origin && git merge origin/master
 
 **Step 2: Run all GUT tests**
 ```bash
-godot --headless -s addons/gut/gut_cmdln.gd
+godot_console --headless -s addons/gut/gut_cmdln.gd
 ```
 Expected: All tests pass, zero failures.
 
@@ -157,7 +157,7 @@ func test_foo_initial_state():
 
 **Step 2: Run test to verify it fails**
 
-Run: `godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
+Run: `godot_console --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
 Expected: FAIL (undefined method or assertion error)
 
 **Step 3: Write minimal implementation**
@@ -168,7 +168,7 @@ Expected: FAIL (undefined method or assertion error)
 
 **Step 4: Run tests to verify they pass**
 
-Run: `godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
+Run: `godot_console --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_foo.gd`
 Expected: PASS
 
 **Step 5: Refactor checkpoint**


### PR DESCRIPTION
## Summary

- Replace all stale `/home/mathdaman/` WSL paths with `C:\Code\` Windows paths
- Replace Linux-only commands: `rsync` → `Copy-Item`, `godot &` → `Start-Process godot_console`, `godot --headless --import` → `godot_console --headless --editor --quit`
- Update `godot` → `godot_console` throughout all skills and the godot-expert agent to match CLAUDE.md

## Files changed

- `.claude/agents/godot-expert.md` — memory file path + GUT commands
- `.claude/skills/run/SKILL.md` — rsync → Copy-Item, all launch/import commands
- `.claude/skills/brainstorming/SKILL.md` — GUT command reference
- `.claude/skills/writing-plans/SKILL.md` — GUT command references (5 occurrences)
- `.claude/skills/executing-plans/SKILL.md` — worktree paths + GUT command
- `.claude/skills/finishing-a-development-branch/SKILL.md` — worktree paths, cd path, rm -rf → Remove-Item, smoketest launch

## Test Plan
- [ ] Verify no `/home/mathdaman`, `DISPLAY=:0`, `pkill`, `rsync`, or `ps aux` remain in any .claude file
- [ ] Run `/run` and confirm `godot_console` launches correctly on Windows
- [ ] Run `/executing-plans` and confirm worktree paths resolve under `C:\Code\worktrees\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)