### PR TITLE
fix: repair Godot launch and Yarn function registration, bump to 4.7.1

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -3,6 +3,14 @@ name: run
 description: Launch the current build of the Outpost Nova game in the Godot editor
 ---
 
+> **Never invoke `godot` / `godot_console` from PATH.** Those are WinGet shims in
+> `%LOCALAPPDATA%\Microsoft\WinGet\Links`; Godot looks for its bundled `GodotSharp\`
+> next to the executable it was launched as, doesn't find it through the shim, and
+> crashes with `.NET: Assemblies not found (gd_mono.cpp:650)` / signal 11. Always go
+> through `tools/godot.ps1`, which resolves the real executable inside the WinGet
+> package directory (override with `$env:GODOT_BIN`). Add `-Console` to attach
+> stdout/stderr.
+
 Determine whether you are running inside a git worktree or the main repo:
 
 ```sh
@@ -24,23 +32,23 @@ pwd
 4. Delete ONLY the compiled YarnProject `.tres` — keep `outpost-nova.yarnproject.import` intact. The `.import` file contains `importer="yarnproject"` which tells Godot to invoke the C# YarnSpinner importer. Deleting the `.import` (or both files) causes headless import to use a generic loader that omits `CompiledYarnProgramBase64`, breaking all dialogue. Deleting just the `.tres` forces a fresh recompile from the worktree's current `.yarn` source files:
    ```sh
    rm -f .godot/imported/outpost-nova.yarnproject-84d4224ec9fa642355d762aa911363c0.tres
-   godot_console --headless --editor --quit --path <worktree_path>
+   C:\Code\outpost-nova\tools\godot.ps1 -Console --headless --editor --quit --path <worktree_path>
    ```
    This works whether or not `.yarn` files were modified in the worktree.
 5. Launch the game from the worktree:
    ```sh
-   Start-Process godot_console -ArgumentList "--path <worktree_path>"
+   Start-Process pwsh -ArgumentList "-NoProfile","-File","C:\Code\outpost-nova\tools\godot.ps1","--path","<worktree_path>"
    ```
 
 **If in the main repo**:
 
 1. Run a headless import to ensure the class cache is up to date (required after any `git pull` that adds new `class_name` scripts — skipping this causes parse errors at runtime):
    ```sh
-   godot_console --headless --editor --quit --path C:\Code\outpost-nova
+   ./tools/godot.ps1 -Console --headless --editor --quit --path C:\Code\outpost-nova
    ```
 2. Launch the game:
    ```sh
-   Start-Process godot_console
+   Start-Process pwsh -ArgumentList "-NoProfile","-File","C:\Code\outpost-nova\tools\godot.ps1","--path","C:\Code\outpost-nova"
    ```
 
 Report to the user that the game is launching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,24 +4,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-**Outpost Nova** is a cozy indie space station-builder game targeting a 30-60 minute MVP vertical slice. Built with **Godot 4.6.1 / GDScript**, Mobile renderer. The MVP implementation plan was completed and its plan files deleted (2026-04-03); work since then is tracked per-feature in `docs/plans/` and `docs/superpowers/plans/`.
+**Outpost Nova** is a cozy indie space station-builder game targeting a 30-60 minute MVP vertical slice. Built with **Godot 4.7.1 (mono) / GDScript + C#**, Mobile renderer. The MVP implementation plan was completed and its plan files deleted (2026-04-03); work since then is tracked per-feature in `docs/plans/` and `docs/superpowers/plans/`.
 
 `docs/index.md` catalogs the project's design, story, world, and character docs — consult it to find existing knowledge, and add a line to it for any new doc under `docs/`.
 
 ## Commands
 
-```bash
-# Launch Godot editor
-godot
+Always invoke Godot through `tools/godot.ps1`, never the `godot` / `godot_console`
+commands on PATH — those are WinGet shims and Godot fails to find its bundled
+`GodotSharp\` through them, crashing with `.NET: Assemblies not found` / signal 11.
+`-Console` selects the console build (stdout/stderr attached); `$env:GODOT_BIN`
+overrides executable discovery.
 
-# Run all GUT tests headlessly
-godot_console --headless -s addons/gut/gut_cmdln.gd
+```powershell
+# Build C# assemblies (required before running — dialogue is C#)
+dotnet build "Outpost Nova.csproj"
+
+# Launch Godot editor
+./tools/godot.ps1
+
+# Launch the game
+./tools/godot.ps1 --path .
+
+# Run all GUT tests headlessly (quote any res:// arg — PowerShell splits on the colon)
+./tools/godot.ps1 -Console --headless --path . -s addons/gut/gut_cmdln.gd "-gdir=res://tests" -gexit
 
 # Run a single test script
-godot_console --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/test_game_state.gd
+./tools/godot.ps1 -Console --headless --path . -s addons/gut/gut_cmdln.gd "-gtest=res://tests/test_game_state.gd" -gexit
 
 # Export builds
-godot_console --headless --export-debug "Windows Desktop"
+./tools/godot.ps1 -Console --headless --export-debug "Windows Desktop"
 ```
 
 ## Architecture

--- a/Outpost Nova.csproj
+++ b/Outpost Nova.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.3">
+<Project Sdk="Godot.NET.Sdk/4.7.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>
@@ -6,6 +6,17 @@
     <RootNamespace>OutpostNova</RootNamespace>
   </PropertyGroup>
   <Import Project="addons/YarnSpinner-Godot/YarnSpinner-Godot.props" />
+  <!--
+    Drop the YarnSpinner source generator from the build. It is a locally-built
+    analyzer DLL that Windows Application Control blocks (CSC warning CS8034 +
+    a Windows Security prompt), so its [YarnFunction] registration code never
+    gets emitted anyway. Yarn functions are registered explicitly in
+    scripts/YarnGameState.cs -> Register(), called from scripts/main.gd.
+    Add new Yarn functions there, not via the attribute alone.
+  -->
+  <ItemGroup>
+    <ProjectReference Remove="addons/YarnSpinner-Godot/SourceGenerator/YarnSpinnerGodotSourceGenerator.csproj" />
+  </ItemGroup>
   <!-- Fix: props file uses backslash exclusions which don't work on Linux -->
   <ItemGroup>
     <Compile Remove="addons/YarnSpinner-Godot/SourceGenerator/**" />

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Outpost Nova"
 run/main_scene="res://scenes/character_creation.tscn"
-config/features=PackedStringArray("4.6", "C#", "Mobile")
+config/features=PackedStringArray("4.7", "C#", "Mobile")
 
 [autoload]
 

--- a/scripts/YarnGameState.cs
+++ b/scripts/YarnGameState.cs
@@ -6,9 +6,15 @@ namespace OutpostNova;
 
 /// <summary>
 /// Exposes GameState query methods as Yarn functions.
-/// Auto-registered by the YarnSpinner source generator — no manual registration needed.
+///
+/// The <see cref="YarnFunctionAttribute"/> below is picked up by the YarnSpinner
+/// source generator, but that generator is a locally-built analyzer DLL which
+/// Windows Application Control can block (CSC warning CS8034). When that happens
+/// no registration code is emitted and Yarn dies at runtime with
+/// "Function get_flag is not present in the library". <see cref="Register"/> does
+/// the same registration explicitly so dialogue works either way.
 /// </summary>
-public static class YarnGameState
+public partial class YarnGameState : Node
 {
     /// <summary>
     /// Returns the value of a GameState flag.
@@ -20,5 +26,15 @@ public static class YarnGameState
         var sceneTree = (SceneTree)Engine.GetMainLoop();
         var gameState = sceneTree.Root.GetNode("GameState");
         return gameState.Call("get_flag", flagId).AsBool();
+    }
+
+    /// <summary>
+    /// Registers every Yarn function on <paramref name="runner"/>. Called from
+    /// GDScript (main.gd) right after the YarnProject is assigned. Re-registering
+    /// an existing name is harmless — the runner replaces the entry.
+    /// </summary>
+    public void Register(DialogueRunner runner)
+    {
+        runner.AddFunction("get_flag", (System.Func<string, bool>)GetFlag);
     }
 }

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -89,6 +89,10 @@ func _setup_dialogue_runner() -> void:
 		return
 	var project := load("res://data/dialogue/outpost-nova.yarnproject")
 	runners[0].SetProject(project)
+	# Yarn functions are registered explicitly rather than relying on the
+	# YarnSpinner source generator, which Windows Application Control can block.
+	var yarn_functions = load("res://scripts/YarnGameState.cs").new()
+	yarn_functions.Register(runners[0])
 
 func _spawn_npcs() -> void:
 	var npc_scripts = {

--- a/tools/godot.ps1
+++ b/tools/godot.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+  Launches the real Godot mono executable, forwarding all arguments.
+
+.DESCRIPTION
+  The `godot` / `godot_console` commands on PATH are WinGet shims living in
+  %LOCALAPPDATA%\Microsoft\WinGet\Links. Godot resolves its bundled GodotSharp\
+  directory relative to the executable it was launched as, so through the shim it
+  never finds the .NET API assemblies and dies with:
+
+      ERROR: .NET: Assemblies not found (gd_mono.cpp:650)
+      CrashHandlerException: Program crashed with signal 11
+
+  Invoking the real executable inside the WinGet package directory avoids this.
+
+.PARAMETER Console
+  Use the *_console.exe build (stdout/stderr attached) instead of the windowed one.
+
+.EXAMPLE
+  ./tools/godot.ps1 -Console --headless --editor --quit --path .
+  ./tools/godot.ps1 --path .
+#>
+[CmdletBinding()]
+param(
+    [switch]$Console,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GodotArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Allow an explicit override for non-WinGet installs.
+if ($env:GODOT_BIN -and (Test-Path $env:GODOT_BIN)) {
+    $exe = $env:GODOT_BIN
+} else {
+    $packages = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    $pattern = if ($Console) { 'Godot_v*_mono_win64_console.exe' } else { 'Godot_v*_mono_win64.exe' }
+    $exe = Get-ChildItem -Path $packages -Filter $pattern -Recurse -File -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+
+if (-not $exe) {
+    throw "Could not locate a Godot mono executable. Set `$env:GODOT_BIN to its full path."
+}
+
+& $exe @GodotArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## Why

The game would not launch, and once launched, every conversation crashed. Two independent causes, both with the same shape: a piece of the toolchain was silently unreachable and the failure surfaced somewhere far from the cause.

### 1. `.NET: Assemblies not found` on launch

```
ERROR: .NET: Assemblies not found
   at: initialize (modules/mono/mono_gd/gd_mono.cpp:650)
CrashHandlerException: Program crashed with signal 11
```

`godot` and `godot_console` on PATH are WinGet **shims** in `%LOCALAPPDATA%\Microsoft\WinGet\Links`. Godot locates its bundled `GodotSharp\` directory relative to the executable it was launched as, so through the shim it never finds the .NET API assemblies and hard-crashes before doing anything else.

**Fix:** `tools/godot.ps1` resolves the real executable inside the WinGet package directory and forwards all arguments. `-Console` selects the console build (stdout/stderr attached); `$env:GODOT_BIN` overrides discovery for non-WinGet installs.

### 2. `Function get_flag is not present in the library`

```
ERROR: System.InvalidOperationException: Function get_flag is not present in the library.
   at Yarn.Library.GetFunction(String name)
   at Yarn.VirtualMachine.CallFunction(...)
   at YarnSpinnerGodot.DialogueRunner.StartDialogue(String nodeName)
```

`get_flag` was registered only via the `[YarnFunction]` attribute, which the YarnSpinner source generator turns into registration code. That generator is a locally-built analyzer DLL that **Windows Application Control blocks**:

```
CSC : warning CS8034: Unable to load Analyzer assembly ...\YarnSpinnerGodot.SourceCodeGenerator.dll :
An Application Control policy has blocked this file. (0x800711C7)
```

Because the block surfaces only as a *warning*, `dotnet build` reported success while emitting zero registration code — and all four `.yarn` files call `get_flag`.

**Fix:** register Yarn functions explicitly. `YarnGameState.Register()` calls `runner.AddFunction("get_flag", ...)`, invoked from `main.gd` right after `SetProject()`. The source generator is then dropped from the build via `ProjectReference Remove`, so the blocked DLL is never built or loaded — which also stops the Windows Security prompt and clears the CS8034 warning.

## Also in this PR

- **Godot 4.6.3 → 4.7.1**, matching the installed editor: `Godot.NET.Sdk` in `Outpost Nova.csproj` and `config/features` in `project.godot`.
- **`CLAUDE.md` and `.claude/skills/run/SKILL.md`** route every Godot invocation through the wrapper, and document the shim trap so it does not get rediscovered the hard way. The GUT commands also gained `--path` / `-gdir` and quoting — bare `res://` args are split by PowerShell on the colon, so the documented test command never actually worked.

## Verification

- `dotnet build "Outpost Nova.csproj"` — **0 warnings, 0 errors** (was 1 warning: the CS8034 block)
- Headless import — clean, no errors
- GUT suite — **82/82 passing**, 5 scripts
- Game launches; dialogue confirmed working in-game

## Not addressed here

Two pre-existing, unrelated bugs surfaced while debugging and were filed separately: see #97 (out-of-bounds tileset atlas row) and #98 (TextLineProvider error on first conversation). Neither is touched by this PR.
