### PR TITLE
fix: pin TextLineProvider.textLanguageCode to the project base language (#108)

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -80,6 +80,7 @@ lineProvider = NodePath("TextLineProvider")
 [node name="TextLineProvider" type="Node" parent="DialogueRunner"]
 script = ExtResource("11")
 YarnProject = ExtResource("9")
+textLanguageCode = "en"
 
 [node name="ArcEvents" type="Node" parent="."]
 script = ExtResource("7")

--- a/tests/test_dialogue_wiring.gd
+++ b/tests/test_dialogue_wiring.gd
@@ -63,6 +63,36 @@ func test_text_line_provider_node_exists_under_runner():
 	assert_true(script != null and script.resource_path == PROVIDER_SCRIPT_PATH,
 		"%s node must use the TextLineProvider script, or lineProvider will fail to bind" % PROVIDER_NODE_NAME)
 
+func _project_base_language() -> String:
+	# Read baseLanguage from the .yarnproject JSON directly rather than through the
+	# C#-backed YarnProject resource, which GUT's assert helpers cannot stringify.
+	var file := FileAccess.open(YARN_PROJECT_PATH, FileAccess.READ)
+	if file == null:
+		return ""
+	var parsed = JSON.parse_string(file.get_as_text())
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return ""
+	return str(parsed.get("baseLanguage", ""))
+
+func test_text_line_provider_language_matches_project_base_language():
+	# Issue #108: unpinned, textLanguageCode defaults to the machine's culture, which
+	# drives [plural]/[select] marker resolution and localisation lookup. Pinning it in
+	# the scene only helps if it cannot drift from the project's declared base language.
+	var base_language := _project_base_language()
+	assert_ne(base_language, "",
+		"could not read baseLanguage from %s" % YARN_PROJECT_PATH)
+	var idx := _find_node_index(PROVIDER_NODE_NAME)
+	if idx == -1:
+		assert_ne(idx, -1, "main.tscn must contain an explicit %s node" % PROVIDER_NODE_NAME)
+		return
+	var language = _get_property(idx, "textLanguageCode")
+	assert_true(language != null,
+		"%s.textLanguageCode must be pinned in the scene, or it defaults to the machine locale" % PROVIDER_NODE_NAME)
+	if language == null:
+		return
+	assert_eq(str(language), base_language,
+		"textLanguageCode must match baseLanguage in the yarnproject")
+
 func test_text_line_provider_has_yarn_project_assigned():
 	var idx := _find_node_index(PROVIDER_NODE_NAME)
 	if idx == -1:


### PR DESCRIPTION
## Summary

- Pins `textLanguageCode = "en"` on the `TextLineProvider` node in `scenes/main.tscn`. Unpinned, it defaulted to `System.Globalization.CultureInfo.CurrentCulture.Name` — the *machine's* locale — rather than the project's declared `baseLanguage`.
- Adds `test_text_line_provider_language_matches_project_base_language`, which reads `baseLanguage` directly from the `.yarnproject` JSON and asserts the scene's pinned value matches, so the two cannot silently drift apart.

The test parses the yarnproject with `FileAccess` + `JSON.parse_string` rather than going through the C#-backed `YarnProject` resource, because GUT's assert helpers crash inside `inst_to_dict()` when handed a C#-scripted Resource.

### Why this mattered

`TextLineProvider.LocaleCode` also defaults to the machine culture and is passed to `lineParser.ParseString`, which drives `[plural]`, `[select]` and `[ordinal]` marker resolution. No Yarn script uses those markers today and `localisation` is empty, so impact was zero — this is a latent trap closed while the node is freshly declared in the scene, not a live defect. See #108 for the full analysis.

## Test Plan

- [x] GUT tests pass headlessly — 88/88 across 6 scripts, output pristine
- [x] Visual smoketest confirmed — conversation started, dialogue lines rendered with real text
- [x] Log captured and grepped: zero hits for `YarnProject is not set`, `compilation errors`, and `Can't locate the text for the line`
- [x] New guard proven non-vacuous in both directions: fails when `textLanguageCode` is absent, and fails with `["fr"] expected to equal ["en"]` when pinned to a drifted value

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACE3cPH817kV76jQqLfSLG
